### PR TITLE
Add Records::AlwaysDestroyable/NotDestroyable/ValidateDestroy

### DIFF
--- a/lib/much-rails/records.rb
+++ b/lib/much-rails/records.rb
@@ -1,0 +1,7 @@
+module MuchRails; end
+module MuchRails::Records
+end
+
+require "much-rails/records/always_destroyable"
+require "much-rails/records/not_destroyable"
+require "much-rails/records/validate_destroy"

--- a/lib/much-rails/records/always_destroyable.rb
+++ b/lib/much-rails/records/always_destroyable.rb
@@ -1,0 +1,27 @@
+require "much-plugin"
+require "much-rails/records/validate_destroy"
+
+# MuchRails::Records::AlwaysDestroyable is a mix-in to always enable destroying
+# a record. It mixes-in MuchRails::Records::ValidateDestroy and hard-codes
+# never adding destruction error messages.
+module MuchRails; end
+module MuchRails::Records; end
+module MuchRails::Records::AlwaysDestroyable
+  include MuchPlugin
+
+  plugin_included do
+    include MuchRails::Records::ValidateDestroy
+  end
+
+  plugin_instance_methods do
+    def destruction_error_messages
+      []
+    end
+
+    private
+
+    def validate_destroy
+      # Do nothing on purpose.
+    end
+  end
+end

--- a/lib/much-rails/records/not_destroyable.rb
+++ b/lib/much-rails/records/not_destroyable.rb
@@ -1,0 +1,27 @@
+require "much-plugin"
+require "much-rails/records/validate_destroy"
+
+# MuchRails::Records::NotDestroyable is a mix-in to disable destroying a
+# record. It mixes-in MuchRails::Records::ValidateDestroy and hard-codes
+# a permanent destruction error message.
+module MuchRails; end
+module MuchRails::Records; end
+module MuchRails::Records::NotDestroyable
+  include MuchPlugin
+
+  plugin_included do
+    include MuchRails::Records::ValidateDestroy
+  end
+
+  plugin_instance_methods do
+    def destruction_error_messages
+      ["#{self.class.name} records can't be deleted."]
+    end
+
+    private
+
+    def validate_destroy
+      # Do nothing on purpose.
+    end
+  end
+end

--- a/lib/much-rails/records/validate_destroy.rb
+++ b/lib/much-rails/records/validate_destroy.rb
@@ -1,0 +1,79 @@
+require "much-plugin"
+
+# MuchRails::Records::ValidateDestroy is used to mix in custom validation
+# logic and handling in destroying records.
+#
+# Include this module and define the #validate_destroy private method. Any
+# calls to #destroy or #destroy! will first check if the record is
+# #destroyable?. This check runs the custom #validate_destroy logic. If the
+# record is not destroyable, the #validate_destroy method should add
+# #destruction_error_messages.
+module MuchRails; end
+module MuchRails::Records; end
+module MuchRails::Records::ValidateDestroy
+  include MuchPlugin
+
+  plugin_instance_methods do
+    def destruction_error_messages
+      @destruction_error_messages ||= []
+    end
+
+    def destroy(validate: true)
+      return false if validate && !destroyable?
+
+      super()
+    end
+
+    def destroy_without_validation
+      destroy(validate: false)
+    end
+
+    def destroy!(as: :base, validate: true)
+      if validate && !destroyable?
+        raise DestructionInvalid.new(self, field_name: as)
+      end
+
+      # `_raise_record_not_destroyed` is from ActiveRecord. This logic was
+      # copied from Rails `destroy!` implementation.
+      destroy(validate: validate) || _raise_record_not_destroyed
+    end
+
+    def destroy_without_validation!(as: :base)
+      destroy!(as: as, validate: false)
+    end
+
+    def destroyable?
+      destruction_error_messages.clear
+      validate_destroy
+      destruction_error_messages.none?
+    end
+
+    def not_destroyable?
+      !destroyable?
+    end
+
+    private
+
+    def validate_destroy
+      raise NotImplementedError
+    end
+  end
+
+  class DestructionInvalid < StandardError
+    attr_reader :record, :destruction_errors
+
+    def initialize(record = nil, field_name: :base)
+      super(record&.destruction_error_messages.to_a.join("\n"))
+
+      @record = record
+
+      messages = record&.destruction_error_messages.to_a
+      @destruction_errors =
+        if messages.any?
+          { field_name.to_sym => messages }
+        else
+          {}
+        end
+    end
+  end
+end

--- a/much-rails.gemspec
+++ b/much-rails.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.18.4"])
 
+  gem.add_dependency("activerecord", ["> 5.0", "< 7.0"])
   gem.add_dependency("activesupport", ["> 5.0", "< 7.0"])
   gem.add_dependency("much-plugin", ["~> 0.2.2"])
   gem.add_dependency("much-result", ["~> 0.1.2"])

--- a/test/unit/lib/much-rails/records/always_destroyable_tests.rb
+++ b/test/unit/lib/much-rails/records/always_destroyable_tests.rb
@@ -1,0 +1,42 @@
+require "assert"
+
+require "much-rails/records/always_destroyable"
+
+module MuchRails::Records::AlwaysDestroyable
+  class UnitTests < Assert::Context
+    desc "MuchRails::Records::AlwaysDestroyable"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Records::AlwaysDestroyable }
+
+    should "include MuchPlugin" do
+      assert_that(subject).includes(MuchPlugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class.new }
+
+    let(:receiver_class) {
+      Class.new do
+        def destroy(*)
+          true
+        end
+
+        include MuchRails::Records::AlwaysDestroyable
+      end
+    }
+
+    should "enable destroying a record" do
+      assert_that(subject.destruction_error_messages).equals([])
+
+      assert_that(subject.destroy).is_true
+
+      # won't raise MuchRails::Records::ValidateDestroy::DestructionInvalid
+      subject.destroy!
+
+      assert_that(subject.destroyable?).equals(true)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/records/not_destroyable_tests.rb
+++ b/test/unit/lib/much-rails/records/not_destroyable_tests.rb
@@ -1,0 +1,39 @@
+require "assert"
+
+require "much-rails/records/not_destroyable"
+
+module MuchRails::Records::NotDestroyable
+  class UnitTests < Assert::Context
+    desc "MuchRails::Records::NotDestroyable"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Records::NotDestroyable }
+
+    should "include MuchPlugin" do
+      assert_that(subject).includes(MuchPlugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class.new }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Records::NotDestroyable
+      end
+    }
+
+    should "disable destroying a record" do
+      assert_that(subject.destruction_error_messages)
+        .equals(["#{subject.class.name} records can't be deleted."])
+
+      assert_that(subject.destroy).equals(false)
+
+      assert_that(-> { subject.destroy! })
+        .raises(MuchRails::Records::ValidateDestroy::DestructionInvalid)
+
+      assert_that(subject.destroyable?).equals(false)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/records/validate_destroy_tests.rb
+++ b/test/unit/lib/much-rails/records/validate_destroy_tests.rb
@@ -1,0 +1,172 @@
+require "assert"
+
+require "much-rails/records/validate_destroy"
+
+module MuchRails::Records::ValidateDestroy
+  class UnitTests < Assert::Context
+    desc "MuchRails::Records::ValidateDestroy"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Records::ValidateDestroy }
+
+    should "include MuchPlugin" do
+      assert_that(subject).includes(MuchPlugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "when init"
+    subject { receiver_class.new }
+
+    setup do
+      Assert.stub_tap_on_call(subject, :destroy!) { |_, call|
+        @destroy_bang_call = call
+      }
+    end
+
+    let(:receiver_class) { FakeRecordMissingValidateDestroyClass }
+
+    should have_imeths :destruction_error_messages
+    should have_imeths :destroy, :destroy!
+    should have_imeths :destroyable?, :not_destroyable?
+
+    should "not implement its #validate_destroy method" do
+      assert_that(-> { subject.instance_eval{ validate_destroy } })
+        .raises(NotImplementedError)
+    end
+  end
+
+  class ReceiverWithDestructionErrorMessagesTests < ReceiverTests
+    desc "with destruction error messages"
+    setup do
+      subject.destruction_errors_exist = true
+    end
+
+    let(:receiver_class) { FakeRecordClass }
+
+    should "validate destroying records" do
+      subject.destroyable?
+      assert_that(subject.destruction_error_messages)
+        .equals(["TEST DESTRUCTION ERROR1", "TEST DESTRUCTION ERROR2"])
+
+      subject.destroy
+      assert_that(subject.super_destroy_called).is_nil
+
+      subject.destroy(validate: false)
+      assert_that(subject.super_destroy_called).is_true
+
+      subject.super_destroy_called = nil
+      subject.destroy_without_validation
+      assert_that(subject.super_destroy_called).is_true
+
+      exception =
+        assert_that(-> { subject.destroy! })
+          .raises(MuchRails::Records::ValidateDestroy::DestructionInvalid)
+      assert_that(exception.message)
+        .equals("TEST DESTRUCTION ERROR1\nTEST DESTRUCTION ERROR2")
+      assert_that(exception.destruction_errors)
+        .equals(base: subject.destruction_error_messages.to_a)
+      assert_that(subject.super_destroy_called).is_true
+
+      exception =
+        assert_that(-> { subject.destroy!(as: :thing) })
+          .raises(MuchRails::Records::ValidateDestroy::DestructionInvalid)
+      assert_that(exception.destruction_errors)
+        .equals(thing: subject.destruction_error_messages.to_a)
+
+      subject.super_destroy_called = nil
+      subject.destroy!(validate: false)
+      assert_that(subject.super_destroy_called).is_true
+
+      @destroy_bang_call = nil
+      subject.destroy_without_validation!
+      assert_that(@destroy_bang_call.args).equals([as: :base, validate: false])
+
+      @destroy_bang_call = nil
+      subject.destroy_without_validation!(as: :thing)
+      assert_that(@destroy_bang_call.args).equals([as: :thing, validate: false])
+
+      assert_that(subject.destroyable?).is_false
+      assert_that(subject.not_destroyable?).is_true
+    end
+  end
+
+  class ReceiverWithNoDestructionErrorMessagesTests < ReceiverTests
+    desc "with no destruction error messages"
+    setup do
+      subject.destruction_errors_exist = false
+    end
+
+    let(:receiver_class) { FakeRecordClass }
+
+    should "validate destroying records" do
+      subject.destroyable?
+      assert_that(subject.destruction_error_messages).equals([])
+
+      subject.destroy
+      assert_that(subject.super_destroy_called).is_true
+
+      subject.super_destroy_called = nil
+      subject.destroy_without_validation
+      assert_that(subject.super_destroy_called).is_true
+
+      subject.super_destroy_called = nil
+      subject.destroy!
+      assert_that(subject.super_destroy_called).is_true
+
+      @destroy_bang_call = nil
+      subject.destroy_without_validation!
+      assert_that(@destroy_bang_call.args).equals([as: :base, validate: false])
+
+      assert_that(subject.destroyable?).is_true
+      assert_that(subject.not_destroyable?).is_false
+    end
+  end
+
+  class DestroyFalseTests < ReceiverTests
+    desc "when #destroy returns false"
+    setup do
+      Assert.stub(subject, :destroy) { false }
+    end
+
+    let(:receiver_class) { FakeRecordClass }
+
+    should "raise ActiveRecord::RecordNotDestroyed" do
+      assert_that(-> { subject.destroy! })
+        .raises(ActiveRecord::RecordNotDestroyed)
+    end
+  end
+
+  require "active_record"
+
+  class FakeRecordBaseClass
+    # Include ActiveRecord::Persistence to test the `destroy!` logic
+    # (the `_raise_record_not_destroyed` method) that we had to re-implement in
+    # the MuchRails::Records::ValidateDestroy.
+    include ActiveRecord::Persistence
+
+    attr_accessor :super_destroy_called
+
+    attr_accessor :destruction_errors_exist
+
+    def destroy
+      @super_destroy_called = true
+    end
+  end
+
+  class FakeRecordClass < FakeRecordBaseClass
+    include MuchRails::Records::ValidateDestroy
+
+    def validate_destroy
+      if destruction_errors_exist
+        destruction_error_messages << "TEST DESTRUCTION ERROR1"
+        destruction_error_messages << "TEST DESTRUCTION ERROR2"
+      end
+    end
+  end
+
+  class FakeRecordMissingValidateDestroyClass < FakeRecordBaseClass
+    include MuchRails::Records::ValidateDestroy
+
+  end
+end


### PR DESCRIPTION
This brings in `Records`, which requires in `Records::NotDestroyable`,
`Records::AlwaysDestroyable` and `Records::ValidateDestroy`. These
mix-ins provide special handling and validations for destroying
records.

Note: This also brings in `ActiveRecord` which was needed in this
effort to support `destroy!` and `destroyable?` methods in the
`Records::ValidateDestroy` mix-in.