### PR TITLE
Add Service, SaveService and CallMethodCallbacks

### DIFF
--- a/lib/much-rails/call_method_callbacks.rb
+++ b/lib/much-rails/call_method_callbacks.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "much-plugin"
+require "much-rails/call_method"
+require "much-rails/config"
+
+# MuchRails::CallMethodCallbacks is a common mix-in for adding before/after
+# callback support to MuchRails::CallMethod. This is separate from the
+# MuchRails::CallMethod mix-in as it adds a bit of overhead (e.g. the
+# `much_rails_call_callbacks_config`) that may not be desired by things
+# just wanting to use the basic `MuchRails::CallMethod`. This allows opting-in
+# to callback support as needed.
+module MuchRails; end
+module MuchRails::CallMethodCallbacks
+  include MuchPlugin
+
+  plugin_included do
+    include MuchRails::CallMethod
+    include MuchRails::Config
+
+    add_config :much_rails_call_callbacks
+  end
+
+  plugin_class_methods do
+    def before_call(&block)
+      much_rails_call_callbacks_config.before_callbacks.append(block) if block
+    end
+
+    def prepend_before_call(&block)
+      much_rails_call_callbacks_config.before_callbacks.prepend(block) if block
+    end
+
+    def after_call(&block)
+      much_rails_call_callbacks_config.after_callbacks.append(block) if block
+    end
+
+    def prepend_after_call(&block)
+      much_rails_call_callbacks_config.after_callbacks.prepend(block) if block
+    end
+
+    def around_call(&block)
+      much_rails_call_callbacks_config.around_callbacks.append(block) if block
+    end
+
+    def prepend_around_call(&block)
+      much_rails_call_callbacks_config.around_callbacks.prepend(block) if block
+    end
+  end
+
+  plugin_instance_methods do
+    def call
+      set_the_return_value_for_the_call_method(nil)
+
+      execute_before_callbacks
+      execute_around_callbacks do
+        set_the_return_value_for_the_call_method(on_call)
+      end
+      execute_after_callbacks
+
+      the_return_value_for_the_call_method
+    end
+
+    # Do nothing by default - override as needed. Prefer this approach over
+    # e.g. `raise NotImplementedError` as it allows any callbacks that have been
+    # attached to run even if the actual `on_call` method was never overridden.
+    def on_call
+    end
+
+    def set_the_return_value_for_the_call_method(value)
+      @the_return_value_for_the_call_method = value
+    end
+
+    def the_return_value_for_the_call_method
+      @the_return_value_for_the_call_method
+    end
+
+    private
+
+    def execute_before_callbacks
+      self.class.much_rails_call_callbacks_config.before_callbacks.each do |callback|
+        instance_exec(&callback)
+      end
+    end
+
+    def execute_around_callbacks(&on_call_block)
+      self.class
+        .much_rails_call_callbacks_config
+        .around_callbacks
+        .reverse
+        .reduce(on_call_block) { |acc_proc, callback_proc|
+          -> { instance_exec(acc_proc, &callback_proc) }
+        }
+        .call
+    end
+
+    def execute_after_callbacks
+      self.class.much_rails_call_callbacks_config.after_callbacks.each do |callback|
+        instance_exec(&callback)
+      end
+    end
+  end
+
+  class MuchRailsCallCallbacksConfig
+    attr_accessor :before_callbacks, :after_callbacks, :around_callbacks
+
+    def initialize
+      @before_callbacks = []
+      @after_callbacks = []
+      @around_callbacks = []
+    end
+  end
+end
+

--- a/lib/much-rails/save_service.rb
+++ b/lib/much-rails/save_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "much-plugin"
+require "much-rails/service"
+require "much-result"
+
+# MuchRails::SaveService is a common mix-in for all service objects that
+# save (e.g. create/update) records.
+module MuchRails::SaveService
+  include MuchPlugin
+
+  plugin_included do
+    include MuchRails::Service
+
+    around_call do |receiver|
+      receiver.call
+    rescue ActiveRecord::RecordInvalid => ex
+      set_the_return_value_for_the_call_method(
+        MuchResult.failure(
+          record: ex.record,
+          exception: ex,
+          validation_errors: ex.record&.errors.to_h,
+          validation_error_messages: ex.record&.errors&.full_messages.to_a))
+    end
+  end
+end

--- a/lib/much-rails/service.rb
+++ b/lib/much-rails/service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "much-plugin"
+require "much-rails/call_method_callbacks"
+require "much-rails/wrap_and_call_method"
+
+# MuchRails::Service is a common mix-in for service objects. It supports
+# the single `.call` method API with before/after callback support.
+module MuchRails; end
+module MuchRails::Service
+  include MuchPlugin
+
+  plugin_included do
+    include MuchRails::CallMethodCallbacks
+    include MuchRails::WrapAndCallMethod
+  end
+end

--- a/test/unit/lib/much-rails/call_method_callbacks_tests.rb
+++ b/test/unit/lib/much-rails/call_method_callbacks_tests.rb
@@ -1,0 +1,180 @@
+require "assert"
+require "much-rails/call_method_callbacks"
+
+require "much-plugin"
+require "much-rails/call_method"
+require "much-rails/config"
+
+module MuchRails::CallMethodCallbacks
+  class UnitTests < Assert::Context
+    desc "MuchRails::SaveService"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::CallMethodCallbacks }
+
+    should "include MuchPlugin" do
+      assert_that(subject).includes(MuchPlugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::CallMethodCallbacks
+
+        attr_reader :values
+
+        def initialize
+          @values = []
+        end
+      end
+    }
+
+    let(:proc1) { -> {} }
+    let(:proc2) { -> {} }
+
+    should have_imeths :before_call, :prepend_before_call, :after_call
+    should have_imeths :prepend_after_call, :around_call, :prepend_around_call
+    should have_imeths :call
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::CallMethod)
+      assert_that(subject).includes(MuchRails::Config)
+    end
+
+    should "know its attributes" do
+      # before_callbacks
+      assert_that(
+        subject.much_rails_call_callbacks_config.before_callbacks.size
+      ).equals(0)
+
+      subject.before_call(&proc1)
+      assert_that(
+        subject.much_rails_call_callbacks_config.before_callbacks.size
+      ).equals(1)
+      assert_that(subject.much_rails_call_callbacks_config.before_callbacks)
+        .equals([proc1])
+
+      subject.prepend_before_call(&proc2)
+      assert_that(
+        subject.much_rails_call_callbacks_config.before_callbacks.size
+      ).equals(2)
+      assert_that(subject.much_rails_call_callbacks_config.before_callbacks)
+        .equals([proc2, proc1])
+
+      # after_callbacks
+      assert_that(subject.much_rails_call_callbacks_config.after_callbacks.size)
+        .equals(0)
+
+      subject.after_call(&proc1)
+      assert_that(subject.much_rails_call_callbacks_config.after_callbacks.size)
+        .equals(1)
+      assert_that(subject.much_rails_call_callbacks_config.after_callbacks)
+        .equals([proc1])
+
+      subject.prepend_after_call(&proc2)
+      assert_that(subject.much_rails_call_callbacks_config.after_callbacks.size)
+        .equals(2)
+      assert_that(subject.much_rails_call_callbacks_config.after_callbacks)
+        .equals([proc2, proc1])
+
+      # around_callbacks
+      assert_that(
+        subject.much_rails_call_callbacks_config.around_callbacks.size
+      ).equals(0)
+
+      subject.around_call(&proc1)
+      assert_that(
+        subject.much_rails_call_callbacks_config.around_callbacks.size
+      ).equals(1)
+      assert_that(subject.much_rails_call_callbacks_config.around_callbacks)
+        .equals([proc1])
+
+      subject.prepend_around_call(&proc2)
+      assert_that(
+        subject.much_rails_call_callbacks_config.around_callbacks.size
+      ).equals(2)
+      assert_that(subject.much_rails_call_callbacks_config.around_callbacks)
+        .equals([proc2, proc1])
+    end
+  end
+
+  class CallMethodTests < ReceiverTests
+    desc "#call"
+    subject { receiver_class }
+
+    setup do
+      subject.before_call do
+        @values << "before 2"
+        true
+      end
+      subject.prepend_before_call do
+        @values << "before 1"
+        true
+      end
+      subject.around_call do |receiver|
+        @values << "start around 2"
+        receiver.call
+        @values << "end around 2"
+        true
+      end
+      subject.prepend_around_call do |receiver|
+        @values << "start around 1"
+        receiver.call
+        @values << "end around 1"
+        true
+      end
+      subject.after_call do
+        @values << "after 2"
+        true
+      end
+      subject.prepend_after_call do
+        @values << "after 1"
+        true
+      end
+
+      subject.class_eval {
+        def on_call
+          @values << "on call"
+          self
+        end
+      }
+    end
+
+    should "execute its callbacks" do
+      return_value = subject.call
+
+      assert_that(return_value).is_instance_of(receiver_class)
+      assert_that(return_value.values)
+        .equals([
+          "before 1",
+          "before 2",
+          "start around 1",
+          "start around 2",
+          "on call",
+          "end around 2",
+          "end around 1",
+          "after 1",
+          "after 2"
+        ])
+    end
+  end
+
+  class MuchRailsCallCallbacksConfigTests < UnitTests
+    desc "unit_class::MuchRailsCallCallbacksConfig"
+    subject { config_class.new }
+
+    let(:config_class) { unit_class::MuchRailsCallCallbacksConfig }
+
+    should have_accessors :before_callbacks, :after_callbacks, :around_callbacks
+
+    should "know its attribute values" do
+      assert_that(subject.before_callbacks).equals([])
+      assert_that(subject.after_callbacks).equals([])
+      assert_that(subject.around_callbacks).equals([])
+    end
+  end
+end

--- a/test/unit/lib/much-rails/save_service_tests.rb
+++ b/test/unit/lib/much-rails/save_service_tests.rb
@@ -1,0 +1,106 @@
+require "assert"
+require "much-rails/save_service"
+
+require "much-plugin"
+require "much-rails/service"
+require "much-result"
+
+module MuchRails::SaveService
+  class UnitTests < Assert::Context
+    desc "MuchRails::SaveService"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::SaveService }
+
+    should "include MuchPlugin" do
+      assert_that(subject).includes(MuchPlugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::SaveService
+
+        def initialize(exception: nil)
+          @exception = exception
+        end
+
+        def on_call
+          raise @exception if @exception
+
+          MuchResult.success
+        end
+      end
+    }
+
+    should "include MuchRails::Service" do
+      assert_that(subject).includes(MuchRails::Service)
+    end
+
+    should "return success" do
+      assert_that(subject.call.success?).is_true
+    end
+  end
+
+  class RecordInvalidErrorSetupTests < ReceiverTests
+    desc "with an ActiveRecord::RecordInvalid error"
+    setup do
+      MuchStub.(exception, :record) { record }
+    end
+
+    let(:exception) { ActiveRecord::RecordInvalid.new }
+  end
+
+  class ExceptionWithRecordErrorsTests < RecordInvalidErrorSetupTests
+    desc "with an exception that has record errors"
+
+    let(:record) { @fake_record ||= FakeRecord.new }
+
+    should "return a failure result with the exception and record errors" do
+      result = subject.call(exception: exception)
+
+      assert_that(result.failure?).is_true
+      assert_that(result.exception).equals(exception)
+      assert_that(result.validation_errors)
+        .equals(some_field: %w[ERROR1 ERROR2])
+      assert_that(result.validation_error_messages)
+        .equals(["some_field ERROR1", "some_field ERROR2"])
+    end
+  end
+
+  class ExceptionWithoutRecordErrorsTests < RecordInvalidErrorSetupTests
+    desc "with an exception that has no record errors"
+
+    let(:record) { nil }
+
+    should "return a failure result with the exception and empty "\
+           "record errors" do
+      result = subject.call(exception: exception)
+
+      assert_that(result.failure?).is_true
+      assert_that(result.exception).equals(exception)
+      assert_that(result.validation_errors).equals({})
+      assert_that(result.validation_error_messages).equals([])
+    end
+  end
+
+  class FakeRecord
+    def errors
+      Errors.new
+    end
+
+    class Errors
+      def to_h
+        { some_field: %w[ERROR1 ERROR2] }
+      end
+
+      def full_messages
+        ["some_field ERROR1", "some_field ERROR2"]
+      end
+    end
+  end
+end

--- a/test/unit/lib/much-rails/service_tests.rb
+++ b/test/unit/lib/much-rails/service_tests.rb
@@ -1,0 +1,35 @@
+require "assert"
+require "much-rails/service"
+
+require "much-plugin"
+require "much-rails/call_method_callbacks"
+require "much-rails/wrap_and_call_method"
+
+module MuchRails::Service
+  class UnitTests < Assert::Context
+    desc "MuchRails::Service"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Service }
+
+    should "include MuchPlugin" do
+      assert_that(subject).includes(MuchPlugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Service
+      end
+    }
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::CallMethodCallbacks)
+      assert_that(subject).includes(MuchRails::WrapAndCallMethod)
+    end
+  end
+end


### PR DESCRIPTION
This brings in `MuchRails::Service`, `MuchRails::SaveService` and
`MuchRails::CallMethodCallbacks`. Descriptions for each mix-in are
included in the mix-in itself.