### PR TITLE
Add InputValue

### DIFF
--- a/lib/much-rails/input_value.rb
+++ b/lib/much-rails/input_value.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "much-rails"
+
+# MuchRails::InputValue is a utility module for dealing with input field values.
+module MuchRails;end
+module MuchRails::InputValue
+  def self.strip(value)
+    return if value.blank?
+
+    value.to_s.strip
+  end
+
+  def self.strip_all(values)
+    Array
+      .wrap(values)
+      .map { |value| strip(value) }
+      .compact
+  end
+end

--- a/test/unit/lib/much-rails/input_value_tests.rb
+++ b/test/unit/lib/much-rails/input_value_tests.rb
@@ -1,0 +1,32 @@
+require "assert"
+require "much-rails/input_value"
+
+module MuchRails::InputValue
+  class UnitTests < Assert::Context
+    desc "MuchRails::InputValue"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::InputValue }
+
+    should have_imeths :strip, :strip_all
+
+    should "know its attributes" do
+      # strip
+      input_value = [nil, "", " "].sample
+      assert_that(subject.strip(input_value)).is_nil
+
+      input_value = [" VALUE  ", "\r VALUE\n"].sample
+      assert_that(subject.strip(input_value)).equals("VALUE")
+
+      assert_that(subject.strip([])).is_nil
+      assert_that(subject.strip({})).is_nil
+
+      # strip_all
+      input_values = [nil, "", " ", " VALUE  "]
+      assert_that(subject.strip_all(input_values)).equals(["VALUE"])
+
+      input_values = [" VALUE1  ", "\r VALUE2\n"]
+      assert_that(subject.strip_all(input_values)).equals(["VALUE1", "VALUE2"])
+    end
+  end
+end


### PR DESCRIPTION
This brings in `MuchRails::InputValue` to support user input
fields, specifically dealing with whitespace and "non-values"
([], nil, "", "  ", etc).