### PR TITLE
Test file clean-ups

### DIFF
--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-rails/version"
 
 require "active_support"

--- a/lib/much-rails/call_method.rb
+++ b/lib/much-rails/call_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-plugin"
 
 # MuchRails::CallMethod is a mix-in to implement the `call`

--- a/lib/much-rails/config.rb
+++ b/lib/much-rails/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-rails"
 require "much-plugin"
 

--- a/lib/much-rails/date.rb
+++ b/lib/much-rails/date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-rails"
 
 module MuchRails; end

--- a/lib/much-rails/records.rb
+++ b/lib/much-rails/records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MuchRails; end
 module MuchRails::Records
 end

--- a/lib/much-rails/records/always_destroyable.rb
+++ b/lib/much-rails/records/always_destroyable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-plugin"
 require "much-rails/records/validate_destroy"
 

--- a/lib/much-rails/records/not_destroyable.rb
+++ b/lib/much-rails/records/not_destroyable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-plugin"
 require "much-rails/records/validate_destroy"
 

--- a/lib/much-rails/records/validate_destroy.rb
+++ b/lib/much-rails/records/validate_destroy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-plugin"
 
 # MuchRails::Records::ValidateDestroy is used to mix in custom validation

--- a/lib/much-rails/save_service.rb
+++ b/lib/much-rails/save_service.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record"
 require "much-plugin"
 require "much-rails/service"
 require "much-result"

--- a/lib/much-rails/time.rb
+++ b/lib/much-rails/time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-rails"
 
 module MuchRails; end

--- a/lib/much-rails/wrap_and_call_method.rb
+++ b/lib/much-rails/wrap_and_call_method.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 require "much-plugin"
 require "much-rails/call_method"
 require "much-rails/wrap_method"
+require "much-result"
 
 # MuchRails::WrapAndCallMethod is a mix-in to implement the `wrap_and_call`
 # and `wrap_and_map_call` class/instance method pattern.

--- a/lib/much-rails/wrap_method.rb
+++ b/lib/much-rails/wrap_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "much-plugin"
 require "much-rails/config"
 

--- a/much-rails.gemspec
+++ b/much-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = "~> 2.5"
 
-  gem.add_development_dependency("assert", ["~> 2.18.4"])
+  gem.add_development_dependency("assert", ["~> 2.19"])
 
   gem.add_dependency("activerecord", ["> 5.0", "< 7.0"])
   gem.add_dependency("activesupport", ["> 5.0", "< 7.0"])

--- a/test/unit/lib/much-rails/call_method_callbacks_tests.rb
+++ b/test/unit/lib/much-rails/call_method_callbacks_tests.rb
@@ -1,10 +1,6 @@
 require "assert"
 require "much-rails/call_method_callbacks"
 
-require "much-plugin"
-require "much-rails/call_method"
-require "much-rails/config"
-
 module MuchRails::CallMethodCallbacks
   class UnitTests < Assert::Context
     desc "MuchRails::SaveService"
@@ -35,6 +31,7 @@ module MuchRails::CallMethodCallbacks
 
     let(:proc1) { -> {} }
     let(:proc2) { -> {} }
+    let(:proc3) { -> {} }
 
     should have_imeths :before_call, :prepend_before_call, :after_call
     should have_imeths :prepend_after_call, :around_call, :prepend_around_call
@@ -47,58 +44,55 @@ module MuchRails::CallMethodCallbacks
 
     should "know its attributes" do
       # before_callbacks
-      assert_that(
-        subject.much_rails_call_callbacks_config.before_callbacks.size
-      ).equals(0)
-
       subject.before_call(&proc1)
-      assert_that(
-        subject.much_rails_call_callbacks_config.before_callbacks.size
-      ).equals(1)
-      assert_that(subject.much_rails_call_callbacks_config.before_callbacks)
-        .equals([proc1])
 
-      subject.prepend_before_call(&proc2)
-      assert_that(
-        subject.much_rails_call_callbacks_config.before_callbacks.size
-      ).equals(2)
-      assert_that(subject.much_rails_call_callbacks_config.before_callbacks)
-        .equals([proc2, proc1])
+      assert_that { subject.before_call(&proc2) }
+        .changes(
+          "subject.much_rails_call_callbacks_config.before_callbacks.dup",
+          from: [proc1],
+          to: [proc1, proc2]
+        )
+
+      assert_that { subject.prepend_before_call(&proc3) }
+        .changes(
+          "subject.much_rails_call_callbacks_config.before_callbacks.dup",
+          from: [proc1, proc2],
+          to: [proc3, proc1, proc2]
+        )
 
       # after_callbacks
-      assert_that(subject.much_rails_call_callbacks_config.after_callbacks.size)
-        .equals(0)
-
       subject.after_call(&proc1)
-      assert_that(subject.much_rails_call_callbacks_config.after_callbacks.size)
-        .equals(1)
-      assert_that(subject.much_rails_call_callbacks_config.after_callbacks)
-        .equals([proc1])
 
-      subject.prepend_after_call(&proc2)
-      assert_that(subject.much_rails_call_callbacks_config.after_callbacks.size)
-        .equals(2)
-      assert_that(subject.much_rails_call_callbacks_config.after_callbacks)
-        .equals([proc2, proc1])
+      assert_that { subject.after_call(&proc2) }
+        .changes(
+          "subject.much_rails_call_callbacks_config.after_callbacks.dup",
+          from: [proc1],
+          to: [proc1, proc2]
+        )
+
+      assert_that { subject.prepend_after_call(&proc3) }
+        .changes(
+          "subject.much_rails_call_callbacks_config.after_callbacks.dup",
+          from: [proc1, proc2],
+          to: [proc3, proc1, proc2]
+        )
 
       # around_callbacks
-      assert_that(
-        subject.much_rails_call_callbacks_config.around_callbacks.size
-      ).equals(0)
-
       subject.around_call(&proc1)
-      assert_that(
-        subject.much_rails_call_callbacks_config.around_callbacks.size
-      ).equals(1)
-      assert_that(subject.much_rails_call_callbacks_config.around_callbacks)
-        .equals([proc1])
 
-      subject.prepend_around_call(&proc2)
-      assert_that(
-        subject.much_rails_call_callbacks_config.around_callbacks.size
-      ).equals(2)
-      assert_that(subject.much_rails_call_callbacks_config.around_callbacks)
-        .equals([proc2, proc1])
+      assert_that { subject.around_call(&proc2) }
+        .changes(
+          "subject.much_rails_call_callbacks_config.around_callbacks.dup",
+          from: [proc1],
+          to: [proc1, proc2]
+        )
+
+      assert_that { subject.prepend_around_call(&proc3) }
+        .changes(
+          "subject.much_rails_call_callbacks_config.around_callbacks.dup",
+          from: [proc1, proc2],
+          to: [proc3, proc1, proc2]
+        )
     end
   end
 

--- a/test/unit/lib/much-rails/call_method_tests.rb
+++ b/test/unit/lib/much-rails/call_method_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/call_method"
 
 module MuchRails::CallMethodTest
@@ -39,8 +38,8 @@ module MuchRails::CallMethodTest
     should "call #new and #call" do
       subject.call
 
-      assert_that(@new_class_method_called).equals(true)
-      assert_that(@on_call_instance_method_called).equals(true)
+      assert_that(@new_class_method_called).is_true
+      assert_that(@on_call_instance_method_called).is_true
     end
   end
 

--- a/test/unit/lib/much-rails/config_tests.rb
+++ b/test/unit/lib/much-rails/config_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/config"
 
 module MuchRails::Config

--- a/test/unit/lib/much-rails/date_tests.rb
+++ b/test/unit/lib/much-rails/date_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/date"
 
 module MuchRails::Date

--- a/test/unit/lib/much-rails/records/always_destroyable_tests.rb
+++ b/test/unit/lib/much-rails/records/always_destroyable_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/records/always_destroyable"
 
 module MuchRails::Records::AlwaysDestroyable
@@ -36,7 +35,7 @@ module MuchRails::Records::AlwaysDestroyable
       # won't raise MuchRails::Records::ValidateDestroy::DestructionInvalid
       subject.destroy!
 
-      assert_that(subject.destroyable?).equals(true)
+      assert_that(subject.destroyable?).is_true
     end
   end
 end

--- a/test/unit/lib/much-rails/records/not_destroyable_tests.rb
+++ b/test/unit/lib/much-rails/records/not_destroyable_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/records/not_destroyable"
 
 module MuchRails::Records::NotDestroyable
@@ -28,12 +27,12 @@ module MuchRails::Records::NotDestroyable
       assert_that(subject.destruction_error_messages)
         .equals(["#{subject.class.name} records can't be deleted."])
 
-      assert_that(subject.destroy).equals(false)
+      assert_that(subject.destroy).is_false
 
       assert_that(-> { subject.destroy! })
         .raises(MuchRails::Records::ValidateDestroy::DestructionInvalid)
 
-      assert_that(subject.destroyable?).equals(false)
+      assert_that(subject.destroyable?).is_false
     end
   end
 end

--- a/test/unit/lib/much-rails/records/validate_destroy_tests.rb
+++ b/test/unit/lib/much-rails/records/validate_destroy_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/records/validate_destroy"
 
 module MuchRails::Records::ValidateDestroy

--- a/test/unit/lib/much-rails/save_service_tests.rb
+++ b/test/unit/lib/much-rails/save_service_tests.rb
@@ -1,10 +1,6 @@
 require "assert"
 require "much-rails/save_service"
 
-require "much-plugin"
-require "much-rails/service"
-require "much-result"
-
 module MuchRails::SaveService
   class UnitTests < Assert::Context
     desc "MuchRails::SaveService"

--- a/test/unit/lib/much-rails/service_tests.rb
+++ b/test/unit/lib/much-rails/service_tests.rb
@@ -1,10 +1,6 @@
 require "assert"
 require "much-rails/service"
 
-require "much-plugin"
-require "much-rails/call_method_callbacks"
-require "much-rails/wrap_and_call_method"
-
 module MuchRails::Service
   class UnitTests < Assert::Context
     desc "MuchRails::Service"

--- a/test/unit/lib/much-rails/time_tests.rb
+++ b/test/unit/lib/much-rails/time_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/time"
 
 module MuchRails::Time

--- a/test/unit/lib/much-rails/wrap_and_call_method_tests.rb
+++ b/test/unit/lib/much-rails/wrap_and_call_method_tests.rb
@@ -1,7 +1,5 @@
 require "assert"
-
 require "much-rails/wrap_and_call_method"
-require "much-result"
 
 module MuchRails::WrapAndCallMethod
   class UnitTests < Assert::Context
@@ -51,7 +49,7 @@ module MuchRails::WrapAndCallMethod
     should have_imeths :wrap_and_call, :wrap_and_map_call
     should have_imeths :wrap_and_capture_call, :wrap_and_capture_call!
 
-    should "include MuchRails::CallMethod and MuchRails::WrapMethod" do
+    should "be configured as expected" do
       assert_that(subject).includes(MuchRails::CallMethod)
       assert_that(subject).includes(MuchRails::WrapMethod)
     end
@@ -69,7 +67,7 @@ module MuchRails::WrapAndCallMethod
         assert_that(wrapped_object).is_instance_of(subject)
         assert_that(wrapped_object.object).equals(objects[index])
         assert_that(wrapped_object.object_kargs).equals(object_kargs)
-        assert_that(wrapped_object.call_called).equals(true)
+        assert_that(wrapped_object.call_called).is_true
       end
     end
   end

--- a/test/unit/lib/much-rails/wrap_method_tests.rb
+++ b/test/unit/lib/much-rails/wrap_method_tests.rb
@@ -1,5 +1,4 @@
 require "assert"
-
 require "much-rails/wrap_method"
 
 module MuchRails::WrapMethod

--- a/test/unit/much-rails_tests.rb
+++ b/test/unit/much-rails_tests.rb
@@ -1,4 +1,5 @@
 require "assert"
+require "much-rails"
 
 module MuchRails
   class UnitTests < Assert::Context


### PR DESCRIPTION
This includes a number of test file clean-ups:

* Update the test file's `require`s to remove the empty line
  between `assert` and the test file name/path.
* Updated tests to close any multi-lined parenthesis on its own
  line.
* Brought in the latest version of `Assert`, which includes the
  `changes` assertion, and is now used in the
  `CallMethodCallbacks` test.
  `Assert` reference: https://github.com/redding/assert/pull/303
* Fixed a few inconsistency issues in the tests, like changing
  `.equals(true)` to `.is_true`, etc.

Note: This also includes `frozen_string_literal: true` on all
non-test files.