### PR TITLE
Add Boolean and NotGiven

### DIFF
--- a/lib/much-rails/boolean.rb
+++ b/lib/much-rails/boolean.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "much-boolean"
+
+module MuchRails
+  Boolean = MuchBoolean
+end

--- a/lib/much-rails/not_given.rb
+++ b/lib/much-rails/not_given.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "much-not-given"
+
+module MuchRails
+  NotGiven = MuchNotGiven
+end

--- a/much-rails.gemspec
+++ b/much-rails.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("activerecord", ["> 5.0", "< 7.0"])
   gem.add_dependency("activesupport", ["> 5.0", "< 7.0"])
+  gem.add_dependency("much-boolean", ["~> 0.1.3"])
+  gem.add_dependency("much-not-given", ["~> 0.1.0"])
   gem.add_dependency("much-plugin", ["~> 0.2.2"])
   gem.add_dependency("much-result", ["~> 0.1.2"])
   gem.add_dependency("oj", ["~> 3.10.18"])

--- a/test/unit/lib/much-rails/boolean_tests.rb
+++ b/test/unit/lib/much-rails/boolean_tests.rb
@@ -1,0 +1,15 @@
+require "assert"
+require "much-rails/boolean"
+
+class MuchRails::Boolean
+  class UnitTests < Assert::Context
+    desc "MuchRails::Boolean"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Boolean }
+
+    should "be MuchBoolean" do
+      assert_that(unit_class).is(MuchBoolean)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/not_given_tests.rb
+++ b/test/unit/lib/much-rails/not_given_tests.rb
@@ -1,0 +1,15 @@
+require "assert"
+require "much-rails/not_given"
+
+module MuchRails::NotGiven
+  class UnitTests < Assert::Context
+    desc "MuchRails::NotGiven"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::NotGiven }
+
+    should "be MuchNotGiven" do
+      assert_that(unit_class).is(MuchNotGiven)
+    end
+  end
+end


### PR DESCRIPTION
This bring in `MuchRails::Boolean` and `MuchRails::NotGiven`.
These will used/required in a future effort when `Actions`
support files are brought in. Both of these modules essentially
alias their respective `much-*` gem.
