### PR TITLE
Add MuchRails::Action result files

### DIFF
--- a/lib/much-rails/action/base_command_result.rb
+++ b/lib/much-rails/action/base_command_result.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "much-rails/action/base_result"
+
+# MuchRails::Action::BaseCommandResult is a base result that, when
+# executed, runs a generic controller command with some given args.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::BaseCommandResult < MuchRails::Action::BaseResult
+  attr_reader :command_name, :command_args
+
+  def initialize(command_name, *command_args)
+    @command_name = command_name
+    @command_args = command_args
+  end
+
+  # This block is called using `instance_exec` in the scope of the controller
+  def execute_block
+    ->(result) { public_send(result.command_name, *result.command_args) }
+  end
+end

--- a/lib/much-rails/action/base_result.rb
+++ b/lib/much-rails/action/base_result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# MuchRails::Action::BaseResult is a base result returned by calling
+# a view action. Its only purpose is to provide an `execute_block` that
+# defines what commands the controller should execute. This block is called
+# using `instance_exec` in the scope of the controller.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::BaseResult
+  def execute_block
+    raise NotImplementedError
+  end
+end

--- a/lib/much-rails/action/head_result.rb
+++ b/lib/much-rails/action/head_result.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "much-rails/action/base_command_result"
+
+# MuchRails::Views::HeadResult is a command result for the `head` controller
+# response command.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::HeadResult < MuchRails::Action::BaseCommandResult
+  def initialize(*head_args)
+    super(:head, *head_args)
+  end
+
+  def head_args
+    command_args
+  end
+end

--- a/lib/much-rails/action/redirect_to_result.rb
+++ b/lib/much-rails/action/redirect_to_result.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "much-rails/action/base_command_result"
+
+# MuchRails::Action::RedirectToResult is a command result for the
+# `redirect_to` controller response command.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::RedirectToResult < MuchRails::Action::BaseCommandResult
+  def initialize(*redirect_to_args)
+    super(:redirect_to, *redirect_to_args)
+  end
+
+  def redirect_to_args
+    command_args
+  end
+end

--- a/lib/much-rails/action/render_result.rb
+++ b/lib/much-rails/action/render_result.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "much-rails/action/base_result"
+
+# MuchRails::Action::RenderResult is a result returned by calling a view
+# action that directs the controller to render a response.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::RenderResult < MuchRails::Action::BaseResult
+  attr_reader :render_view_model, :render_kargs
+
+  def initialize(render_view_model, **render_kargs)
+    @render_view_model = render_view_model
+    @render_kargs = render_kargs
+  end
+
+  # This block is called using `instance_exec` in the scope of the controller
+  def execute_block
+    ->(result) {
+      @view_model = result.render_view_model
+      render(**result.render_kargs)
+    }
+  end
+end

--- a/lib/much-rails/action/send_data_result.rb
+++ b/lib/much-rails/action/send_data_result.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "much-rails/action/base_command_result"
+
+# MuchRails::Action::SendDataResult is a command result for the `send_data`
+# controller response command.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::SendDataResult < MuchRails::Action::BaseCommandResult
+  def initialize(*send_data_args)
+    super(:send_data, *send_data_args)
+  end
+
+  def send_data_args
+    command_args
+  end
+end

--- a/lib/much-rails/action/send_file_result.rb
+++ b/lib/much-rails/action/send_file_result.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "much-rails/action/base_command_result"
+
+# MuchRails::Action::SendFileResult is a command result for the `send_file`
+# controller response command.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::SendFileResult < MuchRails::Action::BaseCommandResult
+  def initialize(*send_file_args)
+    super(:send_file, *send_file_args)
+  end
+
+  def send_file_args
+    command_args
+  end
+end

--- a/lib/much-rails/action/unprocessable_entity_result.rb
+++ b/lib/much-rails/action/unprocessable_entity_result.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "much-rails/action/base_result"
+
+# MuchRails::Action::UnprocessableEntityResult is a result returned by
+# calling a view action that is not valid. It returns JSON with the validation
+# details.
+#
+# This result is only returned if, after validating the action, there are
+# errors. Most commonly this occurs when validating form submission params.
+module MuchRails; end
+module MuchRails::Action; end
+class MuchRails::Action::UnprocessableEntityResult <
+        MuchRails::Action::BaseResult
+  attr_reader :errors
+
+  def initialize(errors)
+    @errors = errors
+  end
+
+  # This block is called using `instance_exec` in the scope of the controller
+  def execute_block
+    ->(result) {
+      render(
+        json: action_errors_json(result.errors),
+        status: :unprocessable_entity
+      )
+    }
+  end
+end

--- a/test/unit/lib/much-rails/action/base_command_result_tests.rb
+++ b/test/unit/lib/much-rails/action/base_command_result_tests.rb
@@ -1,0 +1,41 @@
+require "assert"
+require "much-rails/action/base_command_result"
+
+class MuchRails::Action::BaseCommandResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::BaseCommandResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::BaseCommandResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject {
+      unit_class.new(
+        :do_something,
+        "VALUE",
+        other_value: "OTHER VALUE"
+      )
+    }
+
+    let(:controller1) { FakeController.new }
+
+    should have_readers :command_name, :command_args
+
+    should "know its attributes" do
+      assert_that(subject.command_name).equals(:do_something)
+      assert_that(subject.command_args)
+        .equals(["VALUE", other_value: "OTHER VALUE"])
+
+      assert_that(controller1.instance_exec(subject, &subject.execute_block))
+        .equals(value: "VALUE", other_value: "OTHER VALUE")
+    end
+  end
+
+  class FakeController
+    def do_something(value, other_value:)
+      { value: value, other_value: other_value }
+    end
+  end
+end

--- a/test/unit/lib/much-rails/action/base_result_tests.rb
+++ b/test/unit/lib/much-rails/action/base_result_tests.rb
@@ -1,0 +1,20 @@
+require "assert"
+require "much-rails/action/base_result"
+
+class MuchRails::Action::BaseResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::BaseResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::BaseResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new }
+
+    should "not implement its #execute_block method" do
+      assert_that { subject.execute_block }.raises(NotImplementedError)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/action/head_result_tests.rb
+++ b/test/unit/lib/much-rails/action/head_result_tests.rb
@@ -1,0 +1,22 @@
+require "assert"
+require "much-rails/action/head_result"
+
+class MuchRails::Action::HeadResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::HeadResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::HeadResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new(:ok) }
+
+    should "know its attributes" do
+      assert_that(subject.command_name).equals(:head)
+      assert_that(subject.command_args).equals([:ok])
+      assert_that(subject.head_args).equals(subject.command_args)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/action/redirect_to_result_tests.rb
+++ b/test/unit/lib/much-rails/action/redirect_to_result_tests.rb
@@ -1,0 +1,22 @@
+require "assert"
+require "much-rails/action/redirect_to_result"
+
+class MuchRails::Action::RedirectToResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::RedirectToResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::RedirectToResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new("URL") }
+
+    should "know its attributes" do
+      assert_that(subject.command_name).equals(:redirect_to)
+      assert_that(subject.command_args).equals(["URL"])
+      assert_that(subject.redirect_to_args).equals(subject.command_args)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/action/render_result_tests.rb
+++ b/test/unit/lib/much-rails/action/render_result_tests.rb
@@ -1,0 +1,41 @@
+require "assert"
+require "much-rails/action/render_result"
+
+class MuchRails::Action::RenderResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::RenderResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::RenderResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new(view_model1, **render_kargs1) }
+
+    let(:controller1) { FakeController.new }
+    let(:view_model1) { Object.new }
+    let(:render_kargs1) {
+      { something: "TEST_VALUE" }
+    }
+
+    should have_readers :render_view_model, :render_kargs
+
+    should "know its attributes" do
+      assert_that(subject.render_view_model).equals(view_model1)
+      assert_that(subject.render_kargs).equals(render_kargs1)
+
+      controller1.instance_exec(subject, &subject.execute_block)
+      assert_that(controller1.view_model).equals(view_model1)
+      assert_that(controller1.render_called_with).equals(render_kargs1)
+    end
+  end
+
+  class FakeController
+    attr_reader :view_model, :render_called_with
+
+    def render(**kargs)
+      @render_called_with = kargs
+    end
+  end
+end

--- a/test/unit/lib/much-rails/action/send_data_result_tests.rb
+++ b/test/unit/lib/much-rails/action/send_data_result_tests.rb
@@ -1,0 +1,22 @@
+require "assert"
+require "much-rails/action/send_data_result"
+
+class MuchRails::Action::SendDataResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::SendDataResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::SendDataResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new("DATA") }
+
+    should "know its attributes" do
+      assert_that(subject.command_name).equals(:send_data)
+      assert_that(subject.command_args).equals(["DATA"])
+      assert_that(subject.send_data_args).equals(subject.command_args)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/action/send_file_result_tests.rb
+++ b/test/unit/lib/much-rails/action/send_file_result_tests.rb
@@ -1,0 +1,22 @@
+require "assert"
+require "much-rails/action/send_file_result"
+
+class MuchRails::Action::SendFileResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::SendFileResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::SendFileResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new("FILE") }
+
+    should "know its attributes" do
+      assert_that(subject.command_name).equals(:send_file)
+      assert_that(subject.command_args).equals(["FILE"])
+      assert_that(subject.send_file_args).equals(subject.command_args)
+    end
+  end
+end

--- a/test/unit/lib/much-rails/action/unprocessable_entity_result_tests.rb
+++ b/test/unit/lib/much-rails/action/unprocessable_entity_result_tests.rb
@@ -1,0 +1,51 @@
+require "assert"
+require "much-rails/action/unprocessable_entity_result"
+
+class MuchRails::Action::UnprocessableEntityResult
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::UnprocessableEntityResult"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::UnprocessableEntityResult }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.new(errors1) }
+
+    let(:controller1) { FakeController.new }
+    let(:errors1) {
+      { something: "ERROR" }
+    }
+
+    should have_readers :errors
+
+    should "know its attributes" do
+      assert_that(subject.errors).equals(errors1)
+
+      controller1.instance_exec(subject, &subject.execute_block)
+      assert_that(controller1.render_called_with)
+        .equals(
+          json: "ERRORS JSON",
+          status: :unprocessable_entity
+        )
+      assert_that(controller1.action_errors_json_called_with)
+        .equals(something: "ERROR")
+    end
+  end
+
+  class FakeController
+    attr_reader :render_called_with, :action_errors_json_called_with
+
+    def render(**kargs)
+      @render_called_with = kargs
+    end
+
+    private
+
+    def action_errors_json(errors)
+      @action_errors_json_called_with = errors
+      "ERRORS JSON"
+    end
+  end
+end


### PR DESCRIPTION
This adds all result oriented files to `MuchRails::Action`. This
is part of an effort to bring in all view action support files.

