### PR TITLE
bring in Dassets; add Railtie that configures/initializes Dassets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ ruby "~> 2.5"
 
 gemspec
 
-gem "pry", "~> 0.12.2"
+gem "pry"

--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -21,5 +21,7 @@ require "much-rails/time"
 require "much-rails/wrap_and_call_method"
 require "much-rails/wrap_method"
 
+require "much-rails/railtie" if defined?(Rails::Railtie)
+
 module MuchRails
 end

--- a/lib/much-rails/assets.rb
+++ b/lib/much-rails/assets.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "dassets"
+require "dassets/server"
+require "dassets-erubi"
+require "dassets-sass"
+
+module MuchRails
+  Assets = Dassets
+end
+
+module MuchRails::Assets
+  def self.configure_for_rails(rails)
+    MuchRails::Assets.configure do |config|
+      # Cache fingerprints in memory for performance gains.
+      config.fingerprint_cache MuchRails::Assets::MemCache.new
+
+      # Cache compiled content in memory in development/test for performance
+      # gains since we aren't caching to the file system. Otherwise, don't
+      # cache in memory as we are caching to the file system and won't benefit
+      # from the in memory cache.
+      much_rails_content_cache =
+        if rails.env.development? || rails.env.test?
+          MuchRails::Assets::MemCache.new
+        else
+          MuchRails::Assets::NoCache.new
+        end
+      config.content_cache much_rails_content_cache
+
+      # Cache out compiled file content to the public folder in non
+      # development/test environments.
+      if !rails.env.development? && !rails.env.test?
+        config.file_store rails.root.join("public")
+      end
+
+      # Look for asset files in the app/assets folder. Support ERB processing
+      # on all .js and .scss files. Support compilation of .scss files.
+      config.source rails.root.join("app", "assets") do |s|
+        # Reject SCSS partials
+        s.filter{ |paths| paths.reject{ |p| File.basename(p) =~ /^_.*\.scss$/ } }
+
+        s.engine "js",   MuchRails::Assets::Erubi::Engine
+        s.engine "scss", MuchRails::Assets::Erubi::Engine
+        s.engine "scss", MuchRails::Assets::Sass::Engine, {
+          syntax:       "scss",
+          output_style: "compressed",
+        }
+      end
+    end
+    MuchRails::Assets.init
+  end
+end

--- a/lib/much-rails/json.rb
+++ b/lib/much-rails/json.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'oj'
+require "oj"
 
 # MuchRails::JSON is an adapter for encoding and decoding JSON values.
 # It uses Oj to do the work: https://github.com/ohler55/oj#-gem

--- a/lib/much-rails/railtie.rb
+++ b/lib/much-rails/railtie.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module MuchRails
+  class Railtie < Rails::Railtie
+    initializer "much-rails-gem" do |app|
+      require "much-rails/assets"
+      MuchRails::Assets.configure_for_rails(::Rails)
+      app.middleware.use MuchRails::Assets::Server
+    end
+  end
+end

--- a/much-rails.gemspec
+++ b/much-rails.gemspec
@@ -22,11 +22,14 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.19"])
 
-  gem.add_dependency("activerecord", ["> 5.0", "< 7.0"])
-  gem.add_dependency("activesupport", ["> 5.0", "< 7.0"])
-  gem.add_dependency("much-boolean", ["~> 0.1.3"])
+  gem.add_dependency("activerecord",   ["> 5.0", "< 7.0"])
+  gem.add_dependency("activesupport",  ["> 5.0", "< 7.0"])
+  gem.add_dependency("dassets",        ["~> 0.15.0"])
+  gem.add_dependency("dassets-erubi",  ["~> 0.1.0"])
+  gem.add_dependency("dassets-sass",   ["~> 0.5.0"])
+  gem.add_dependency("much-boolean",   ["~> 0.1.3"])
   gem.add_dependency("much-not-given", ["~> 0.1.0"])
-  gem.add_dependency("much-plugin", ["~> 0.2.2"])
-  gem.add_dependency("much-result", ["~> 0.1.2"])
-  gem.add_dependency("oj", ["~> 3.10.18"])
+  gem.add_dependency("much-plugin",    ["~> 0.2.2"])
+  gem.add_dependency("much-result",    ["~> 0.1.2"])
+  gem.add_dependency("oj",             ["~> 3.10.18"])
 end

--- a/test/unit/assets_tests.rb
+++ b/test/unit/assets_tests.rb
@@ -1,0 +1,125 @@
+require "assert"
+require "much-rails/assets"
+
+module MuchRails::Assets
+  class UnitTests < Assert::Context
+    desc "MuchRails::Assets"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Assets }
+
+    should have_imeths :configure_for_rails
+
+    should "be Dassets" do
+      assert_that(unit_class).is(Dassets)
+    end
+  end
+
+  class ConfigureTests < UnitTests
+    desc "when configured"
+
+    setup do
+      subject.reset
+
+      in_development_env = Factory.boolean
+      Assert.stub(FakeRails.env, :development?) { in_development_env }
+      Assert.stub(FakeRails.env, :test?) { !in_development_env }
+
+      Assert.stub_on_call(subject, :init) { |call|
+        @init_call = call
+      }
+
+      subject.configure_for_rails(FakeRails)
+    end
+
+    should "configure the fingerprint cache to use a memory cache" do
+      assert_that(subject.config.fingerprint_cache)
+        .is_instance_of(subject::MemCache)
+    end
+
+    should "configure the content cache to use a memory cache" do
+      assert_that(subject.config.content_cache)
+        .is_instance_of(subject::MemCache)
+    end
+
+    should "not configure a file store" do
+      assert_that(subject.config.file_store.root)
+        .is_not_equal_to(FakeRails.root.join("public"))
+    end
+
+    should "configure the app's app/assets folder as a source" do
+      source =
+        subject.config.sources.detect { |source|
+          source.path == FakeRails.root.join("app", "assets").to_s
+        }
+
+      assert_that(source).is_not_nil
+      assert_that(source.engines["js"].size).equals(1)
+      assert_that(source.engines["js"].first)
+        .is_instance_of(subject::Erubi::Engine)
+      assert_that(source.engines["scss"].size).equals(2)
+      assert_that(source.engines["scss"].first)
+        .is_instance_of(subject::Erubi::Engine)
+      assert_that(source.engines["scss"].last)
+        .is_instance_of(subject::Sass::Engine)
+    end
+
+    should "initialize itself" do
+      assert_that(@init_call).is_not_nil
+    end
+  end
+
+  class ConfigureNotInDevelopmentOrTestEnvsTests < UnitTests
+    desc "when configured not in development or test environments"
+
+    setup do
+      subject.reset
+
+      Assert.stub_on_call(subject, :init) { |call|
+        @init_call = call
+      }
+
+      subject.configure_for_rails(FakeRails)
+    end
+
+    should "configure the content cache to use no cache" do
+      assert_that(subject.config.content_cache)
+        .is_instance_of(subject::NoCache)
+    end
+
+    should "configure a file store for the app's public folder" do
+      assert_that(subject.config.file_store.root)
+        .equals(FakeRails.root.join("public"))
+    end
+  end
+
+  module FakeRails
+    def self.env
+      @env ||= FakeRailsEnv.new
+    end
+
+    def self.root
+      @root ||= FakeRailsRoot.new
+    end
+  end
+
+  class FakeRailsEnv
+    def development?
+      false
+    end
+
+    def test?
+      false
+    end
+  end
+
+  class FakeRailsRoot
+    def initialize
+      @root_path = Pathname.new(Factory.path)
+    end
+
+    def join(*args)
+      @root_path.join(File.join(*args))
+    end
+  end
+end


### PR DESCRIPTION
This aliases Dassets as MuchRails::Assets as is the convention
for dependencies that MuchRails brings in. This also adds a Railtie
and configuration method for configuring Dassets in a default
manner. This is an opinionated default. In the future, we'll most
likely add something like profiles or provide a way to manually
configure source behavior.
