### PR TITLE
Add Action::ChangeAction mix-in

### DIFF
--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -5,7 +5,6 @@ require "active_support/core_ext"
 
 require "much-rails/version"
 require "much-rails/action"
-require "much-rails/action/change_action"
 require "much-rails/boolean"
 require "much-rails/call_method"
 require "much-rails/call_method_callbacks"

--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext"
 
 require "much-rails/version"
 require "much-rails/action"
+require "much-rails/action/change_action"
 require "much-rails/boolean"
 require "much-rails/call_method"
 require "much-rails/call_method_callbacks"

--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "active_record"
+require "much-rails/action/change_action"
+require "much-rails/action/destroy_action"
 require "much-rails/action/head_result"
 require "much-rails/action/redirect_to_result"
 require "much-rails/action/render_result"
+require "much-rails/action/save_action"
 require "much-rails/action/send_data_result"
 require "much-rails/action/send_file_result"
 require "much-rails/action/unprocessable_entity_result"

--- a/lib/much-rails/action/destroy_action.rb
+++ b/lib/much-rails/action/destroy_action.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "much-rails/plugin"
+require "much-rails/action/change_action"
+
+# MuchRails::Action::DestroyAction defines the common behaviors for all view
+# action classes that destroy records.
+module MuchRails; end
+module MuchRails::Action; end
+module MuchRails::Action::DestroyAction
+  include MuchRails::Plugin
+
+  plugin_included do
+    include MuchRails::Action::ChangeAction
+  end
+
+  plugin_class_methods do
+    def destroy_result(&block)
+      change_result(&block)
+    end
+  end
+
+  plugin_instance_methods do
+    def destroy_result
+      change_result
+    end
+
+    private
+
+    def undefined_change_result_block_error_message
+      "A `destroy_result` block must be defined."
+    end
+  end
+end

--- a/lib/much-rails/action/save_action.rb
+++ b/lib/much-rails/action/save_action.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "much-rails/plugin"
+require "much-rails/action/change_action"
+
+# MuchRails::Action::SaveAction defines the common behaviors for all view
+# action classes that save records.
+module MuchRails; end
+module MuchRails::Action; end
+module MuchRails::Action::SaveAction
+  include MuchRails::Plugin
+
+  plugin_included do
+    include MuchRails::Action::ChangeAction
+  end
+
+  plugin_class_methods do
+    def save_result(&block)
+      change_result(&block)
+    end
+  end
+
+  plugin_instance_methods do
+    def save_result
+      change_result
+    end
+
+    private
+
+    def undefined_change_result_block_error_message
+      "A `save_result` block must be defined."
+    end
+  end
+end

--- a/test/unit/action/change_action_tests.rb
+++ b/test/unit/action/change_action_tests.rb
@@ -1,0 +1,213 @@
+require "assert"
+require "much-rails/action/change_action"
+
+module MuchRails::Action::ChangeAction
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::ChangeAction"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::ChangeAction }
+
+    should "include MuchRails::Plugin" do
+      assert_that(subject).includes(MuchRails::Plugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Action::ChangeAction
+
+        change_result { MuchRails::Result.success(something: something_value) }
+
+        on_call {}
+
+        def something_value
+          "SOMETHING VALUE"
+        end
+
+        private
+
+        def undefined_change_result_block_error_message
+          "UNDEFINED CHANGE RESULT BLOCK"
+        end
+      end
+    }
+
+    should have_imeths :change_result
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::Config)
+      assert_that(subject).includes(MuchRails::Action)
+
+      assert_that(subject.much_rails_action_change_action_config)
+        .is_instance_of(
+          MuchRails::Action::ChangeAction::MuchRailsActionChangeActionConfig
+        )
+      assert_that(
+        subject.much_rails_action_change_action_config.change_result_block
+      ).is_not_nil
+    end
+  end
+
+  class InitTests < ReceiverTests
+    desc "when init"
+    subject { receiver_class.new(params: {}) }
+
+    setup do
+      Assert.stub(subject, :any_unextracted_change_result_validation_errors?) {
+        false
+      }
+    end
+
+    should have_imeths :change_result
+
+    should "render the default response" do
+      result = subject.call
+
+      assert_that(result.command_name).equals(:head)
+      assert_that(result.command_args).equals([:ok])
+    end
+  end
+
+  class RecordErrorsWithResultExceptionTests < InitTests
+    desc "with record errors and a result exception"
+    subject { receiver_class.new(params: {}) }
+
+    setup do
+      Assert.stub(subject, :any_unextracted_change_result_validation_errors?) {
+        true
+      }
+      Assert.stub(result_exception, :message) { "ERROR MESSAGE" }
+      Assert.stub(result_exception, :backtrace) { ["BACKTRACE LINE1"] }
+
+      Assert.stub(subject, :change_result) { change_result1 }
+    end
+
+    let(:result_exception) { RuntimeError.new }
+    let(:change_result1) {
+      MuchRails::Result.failure(exception: result_exception)
+    }
+
+    should "raise a MuchRails::Action::ActionError" do
+      exception =
+        assert_that { subject.call }.raises(MuchRails::Action::ActionError)
+
+      assert_that(exception.message).equals("ERROR MESSAGE")
+      assert_that(exception.backtrace).equals(["BACKTRACE LINE1"])
+    end
+  end
+
+  class RecordErrorsWithNoResultExceptionTests < InitTests
+    desc "with record errors and no result exception"
+    subject { receiver_class.new(params: {}) }
+
+    setup do
+      Assert.stub(subject, :any_unextracted_change_result_validation_errors?) {
+        true
+      }
+      Assert.stub(subject, :change_result) { change_result1 }
+    end
+
+    let(:change_result1) { MuchRails::Result.failure }
+
+    should "raise a MuchRails::Action::ActionError" do
+      exception =
+        assert_that { subject.call }.raises(MuchRails::Action::ActionError)
+
+      assert_that(exception.message)
+        .equals(
+          "#{change_result1.inspect} has validation errors that were not "\
+          "handled by the Action: #{change_result1.validation_errors.inspect}."
+        )
+    end
+  end
+
+  class ChangeResultMethodTests < InitTests
+    desc "#change_result method"
+    subject { receiver_class.new(params: {}) }
+
+    should "memoize and return the expected Result" do
+      result = subject.change_result
+
+      assert_that(result.success?).is_true
+      assert_that(result.something).equals("SOMETHING VALUE")
+      assert_that(result).is(subject.change_result)
+    end
+
+    should "raise an error when a configured change_result block is not given" do
+      Assert.stub(
+        receiver_class.much_rails_action_change_action_config,
+        :change_result_block
+      ) { nil }
+      exception =
+        assert_that { subject.change_result }.raises(unit_class::Error)
+      assert_that(exception.message).equals("UNDEFINED CHANGE RESULT BLOCK")
+    end
+  end
+
+  class AnyUnextractedChangeResultValidationErrorsMethodTests < ReceiverTests
+    desc "#any_unextracted_change_result_validation_errors? method"
+    subject { receiver_class.new(params: {}) }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Action::ChangeAction
+
+        change_result { MuchRails::Result.success }
+      end
+    }
+
+    should "return false" do
+      subject.change_result
+
+      assert_that(subject.any_unextracted_change_result_validation_errors?)
+        .is_false
+    end
+  end
+
+  class NoValidationErrorsTests < AnyUnextractedChangeResultValidationErrorsMethodTests
+    desc "with no validation errors"
+    subject { receiver_class.new(params: {}) }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Action::ChangeAction
+
+        change_result { MuchRails::Result.failure(validation_errors: {}) }
+      end
+    }
+
+    should "return false" do
+      subject.change_result
+
+      assert_that(subject.any_unextracted_change_result_validation_errors?)
+        .is_false
+    end
+  end
+
+  class ValidationErrorsTests < AnyUnextractedChangeResultValidationErrorsMethodTests
+    desc "with validation errors"
+    subject { receiver_class.new(params: {}) }
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Action::ChangeAction
+
+        change_result {
+          MuchRails::Result.failure(validation_errors: { name: "TEST ERROR" })
+        }
+      end
+    }
+
+    should "return true" do
+      subject.change_result
+
+      assert_that(subject.any_unextracted_change_result_validation_errors?)
+        .is_true
+    end
+  end
+end

--- a/test/unit/action/destroy_action_tests.rb
+++ b/test/unit/action/destroy_action_tests.rb
@@ -1,0 +1,75 @@
+require "assert"
+require "much-rails/action/destroy_action"
+
+module MuchRails::Action::DestroyAction
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::DestroyAction"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::DestroyAction }
+
+    should "include MuchRails::Plugin" do
+      assert_that(subject).includes(MuchRails::Plugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class }
+
+    setup do
+      Assert.stub_on_call(receiver_class, :change_result) { |call|
+        @change_action_class_change_result_call = call
+      }
+    end
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Action::DestroyAction
+
+        destroy_result { MuchRails::Result.success  }
+
+        on_call {}
+      end
+    }
+
+    should have_imeths :destroy_result
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::Action::ChangeAction)
+    end
+
+    should "call .change_result for its .destroy_result method" do
+      subject.destroy_result
+
+      assert_that(@change_action_class_change_result_call).is_not_nil
+    end
+  end
+
+  class InitTests < ReceiverTests
+    desc "when init"
+    subject { receiver_class.new(params: {}) }
+
+    should have_imeths :destroy_result
+
+    should "call #change_result for its #destroy_result method" do
+      Assert.stub_on_call(subject, :change_result) { |call|
+        @change_action_instance_change_result_call = call
+      }
+
+      subject.destroy_result
+      assert_that(@change_action_instance_change_result_call).is_not_nil
+    end
+
+    should "raise a custom error message if no destroy result block defined" do
+      Assert.stub(
+        receiver_class.much_rails_action_change_action_config,
+        :change_result_block
+      ) { nil }
+
+      exception = assert_that { subject.destroy_result }.raises
+      assert_that(exception.message)
+        .equals("A `destroy_result` block must be defined.")
+    end
+  end
+end

--- a/test/unit/action/save_action_tests.rb
+++ b/test/unit/action/save_action_tests.rb
@@ -1,0 +1,75 @@
+require "assert"
+require "much-rails/action/save_action"
+
+module MuchRails::Action::SaveAction
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::SaveAction"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::Action::SaveAction }
+
+    should "include MuchRails::Plugin" do
+      assert_that(subject).includes(MuchRails::Plugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class }
+
+    setup do
+      Assert.stub_on_call(receiver_class, :change_result) { |call|
+        @change_action_class_change_result_call = call
+      }
+    end
+
+    let(:receiver_class) {
+      Class.new do
+        include MuchRails::Action::SaveAction
+
+        save_result { MuchRails::Result.success  }
+
+        on_call {}
+      end
+    }
+
+    should have_imeths :save_result
+
+    should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::Action::ChangeAction)
+    end
+
+    should "call .change_result for its .save_result method" do
+      subject.save_result
+
+      assert_that(@change_action_class_change_result_call).is_not_nil
+    end
+  end
+
+  class InitTests < ReceiverTests
+    desc "when init"
+    subject { receiver_class.new(params: {}) }
+
+    should have_imeths :save_result
+
+    should "call #change_result for its #save_result method" do
+      Assert.stub_on_call(subject, :change_result) { |call|
+        @change_action_instance_change_result_call = call
+      }
+
+      subject.save_result
+      assert_that(@change_action_instance_change_result_call).is_not_nil
+    end
+
+    should "raise a custom error message if no save result block is defined" do
+      Assert.stub(
+        receiver_class.much_rails_action_change_action_config,
+        :change_result_block
+      ) { nil }
+
+      exception = assert_that { subject.save_result }.raises
+      assert_that(exception.message)
+        .equals("A `save_result` block must be defined.")
+    end
+  end
+end


### PR DESCRIPTION
This brings in the `MuchRails::Action::ChangeAction` mix-in which
defines common behavior for upcoming `SaveAction` and `DestroyAction`
mix-ins.

# Other Changes
### Add `SaveAction` and `DestroyAction` mix-ins

This brings in `MuchRails::Action::SaveAction` and
`MuchRails::Action::DestroyAction` mix-ins. These mix-ins define
their save/destroy result, which aliases `change_result` on the
`ChangeAction` mix-in they both bring in.