### PR TITLE
Add Layout::Helper

### DIFF
--- a/lib/much-rails/layout.rb
+++ b/lib/much-rails/layout.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "much-rails/layout/helper"
 require "much-rails/plugin"
 require "much-rails/view_models/breadcrumb"
 

--- a/lib/much-rails/layout/helper.rb
+++ b/lib/much-rails/layout/helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module MuchRails; end
+module MuchRails::Layout; end
+module MuchRails::Layout::Helper
+  # This is used to render layouts. It is designed to be used in
+  # the Rails layout template to render the nested layouts.
+  def much_rails_render_layouts(view_model, &content)
+    unless view_model.is_a?(MuchRails::Layout)
+      raise(
+        TypeError,
+        "A View Model that mixes in MuchRails::Layout expected; "\
+        "got #{view_model.class}."
+      )
+    end
+    view_model
+      .layouts
+      .reverse
+      .reduce(content) { |render_proc, template_path|
+        -> { render(File.join("layouts", template_path), &render_proc) }
+      }
+      .call
+  end
+end

--- a/lib/much-rails/railtie.rb
+++ b/lib/much-rails/railtie.rb
@@ -3,6 +3,9 @@
 module MuchRails
   class Railtie < Rails::Railtie
     initializer "much-rails-gem" do |app|
+      # Helpers
+      ActionView::Base.include(MuchRails::Layout::Helper)
+
       require "much-rails/assets"
       MuchRails::Assets.configure_for_rails(::Rails)
       app.middleware.use MuchRails::Assets::Server


### PR DESCRIPTION
This adds `MuchRails::Layout::Helper` to support rendering
layouts. This also updates `Railtie` to include
`MuchRails::Layout::Helper` as part of its initialization
process.
