### PR TITLE
add MuchRails::Action::Controller

### DIFF
--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -26,6 +26,14 @@ module MuchRails::Action
     [ActiveRecord::RecordInvalid]
   end
 
+  def self.raise_response_exceptions=(value)
+    @raise_response_exceptions = value
+  end
+
+  def self.raise_response_exceptions?
+    !!@raise_response_exceptions
+  end
+
   plugin_included do
     include MuchRails::Config
     include MuchRails::WrapAndCallMethod
@@ -110,7 +118,6 @@ module MuchRails::Action
   plugin_instance_methods do
     def initialize(params:)
       @params = params.to_h.with_indifferent_access
-
       @errors = Hash.new { |hash, key| hash[key] = [] }
     end
 

--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "much-rails/action/router"
+require "much-rails/plugin"
+
+# MuchRails::Action::Controller defines the behaviors for controllers processing
+# MuchRails::Actions.
+module MuchRails; end
+module MuchRails::Action; end
+module MuchRails::Action::Controller
+  include MuchRails::Plugin
+
+  plugin_included do
+    attr_reader :much_rails_action_class
+
+    before_action :require_much_rails_action_class
+    before_action :permit_all_much_rails_action_params
+  end
+
+  plugin_instance_methods do
+    define_method(MuchRails::Action::Router::CONTROLLER_METHOD_NAME) do
+      respond_to do |format|
+        format.public_send(much_rails_action_class.format) {
+          result =
+            much_rails_action_class.call(
+              params: much_rails_action_params,
+              current_user: current_user,
+              request: request
+            )
+          instance_exec(result, &result.execute_block)
+        }
+      end
+    end
+
+    def much_rails_action_class_name
+      "::#{params[MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME]}"
+    end
+
+    def much_rails_action_params
+      # If a `params_root` value is specified, pull the params from that key and
+      # merge them into the base params.
+      Array
+        .wrap(much_rails_action_class&.params_root)
+        .reduce(
+          params
+            .to_h
+            .except(
+              MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME,
+              :controller,
+              :action
+            )
+        ) { |acc, root|
+          acc.merge(acc[root].to_h)
+        }
+    end
+
+    def require_much_rails_action_class
+      begin
+        @much_rails_action_class = much_rails_action_class_name.constantize
+      rescue NameError => ex
+        if MuchRails::Action.raise_response_exceptions?
+          raise(
+            MuchRails::Action::ActionError,
+            "No Action class defined for #{much_rails_action_class_name.inspect}.",
+            cause: ex
+          )
+        else
+          head(:not_found)
+        end
+      end
+    end
+
+    def permit_all_much_rails_action_params
+      params.permit!
+    end
+  end
+end

--- a/lib/much-rails/action/unprocessable_entity_result.rb
+++ b/lib/much-rails/action/unprocessable_entity_result.rb
@@ -21,10 +21,16 @@ class MuchRails::Action::UnprocessableEntityResult <
   # This block is called using `instance_exec` in the scope of the controller
   def execute_block
     ->(result) {
-      render(
-        json: action_errors_json(result.errors),
-        status: :unprocessable_entity
-      )
+      errors =
+        Array
+          .wrap(much_rails_action_class&.params_root)
+          .reduce(result.errors) { |acc, root|
+            acc.merge(
+              acc.transform_keys { |error_key| "#{root}[#{error_key}]" }
+            )
+          }
+
+      render(json: errors, status: :unprocessable_entity)
     }
   end
 end

--- a/lib/much-rails/railtie.rb
+++ b/lib/much-rails/railtie.rb
@@ -9,6 +9,13 @@ module MuchRails
       require "much-rails/assets"
       MuchRails::Assets.configure_for_rails(::Rails)
       app.middleware.use MuchRails::Assets::Server
+
+      # This should be `true` in development so things fail fast and give the
+      # developers rich error information for debugging purposes.
+      #
+      # This should be `false` in all other envs so proper HTTP response
+      # statuses are returned.
+      MuchRails::Action.raise_response_exceptions = Rails.development?
     end
   end
 end

--- a/test/support/actions/show.rb
+++ b/test/support/actions/show.rb
@@ -1,0 +1,9 @@
+require "much-rails/action"
+
+module Actions
+  class Show
+    include MuchRails::Action
+
+    params_root :nested
+  end
+end

--- a/test/support/fake_action_controller.rb
+++ b/test/support/fake_action_controller.rb
@@ -1,0 +1,60 @@
+require "much-rails/plugin"
+
+module FakeActionController
+  include MuchRails::Plugin
+
+  after_plugin_included do
+    include MuchRails::Action::Controller
+
+    attr_reader :params
+    attr_reader :head_called_with, :render_called_with
+  end
+
+  plugin_class_methods do
+    def before_action(method_name)
+      before_actions << method_name
+    end
+
+    def before_actions
+      @before_actions ||= []
+    end
+  end
+
+  plugin_instance_methods do
+    def initialize(params)
+      @params = FakeParams.new(params)
+      self.class.before_actions.each do |before_action|
+        self.public_send(before_action)
+      end
+    end
+
+    def head(*args)
+      @head_called_with = args
+      self
+    end
+
+    def render(**kargs)
+      @render_called_with = kargs
+    end
+  end
+
+  class FakeParams
+    def initialize(params)
+      @params = params
+    end
+
+    def permit!
+      @permit_called = true
+      self
+    end
+
+    def [](key)
+      @params[key]
+    end
+
+    def to_h
+      raise "params haven't been permitted" unless @permit_called
+      @params
+    end
+  end
+end

--- a/test/unit/action/controller_tests.rb
+++ b/test/unit/action/controller_tests.rb
@@ -1,0 +1,133 @@
+require "assert"
+require "much-rails/action/controller"
+
+require "test/support/actions/show"
+require "test/support/fake_action_controller"
+
+module MuchRails::Action::Controller
+  class UnitTests < Assert::Context
+    desc "MuchRails::Action::Controller"
+    subject { unit_module }
+
+    let(:unit_module) { MuchRails::Action::Controller }
+
+    should "include MuchRails::Plugin" do
+      assert_that(subject).includes(MuchRails::Plugin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject { receiver_class }
+
+    let(:receiver_class) {
+      Class.new { include FakeActionController }
+    }
+  end
+
+  class ReceiverInitTests < ReceiverTests
+    desc "when init"
+    subject { receiver_class.new(params1) }
+
+    let(:params1) {
+      {
+        MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME => "Actions::Show",
+        controller: "actions",
+        action: "show",
+        nested: {
+          value: "VALUE 1"
+        },
+      }
+    }
+
+    should have_readers :much_rails_action_class
+
+    should have_imeths MuchRails::Action::Router::CONTROLLER_METHOD_NAME
+    should have_imeths :much_rails_action_class_name
+    should have_imeths :much_rails_action_params
+    should have_imeths :require_much_rails_action_class
+    should have_imeths :permit_all_much_rails_action_params
+
+    should "know its attributes" do
+      assert_that(subject.much_rails_action_class_name)
+        .equals("::Actions::Show")
+
+      assert_that(subject.much_rails_action_params)
+        .equals(
+          nested: { value: "VALUE 1" },
+          value: "VALUE 1",
+        )
+
+      assert_that(subject.much_rails_action_class).equals(Actions::Show)
+    end
+  end
+
+  class ReceiverInitWithUnknownActionClassTests < ReceiverTests
+    desc "when init with an unknown action class"
+    subject { receiver_class.new(params1) }
+
+    let(:params1) {
+      {
+        MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME => "Actions::Unknown",
+      }
+    }
+
+    should "return not found when not raising response exceptions" do
+      Assert.stub(MuchRails::Action, :raise_response_exceptions?) { false }
+
+      assert_that(subject.much_rails_action_class).is_nil
+      assert_that(subject.head_called_with).equals([:not_found])
+    end
+
+    should "raise an exception when raising response exceptions" do
+      Assert.stub(MuchRails::Action, :raise_response_exceptions?) { true }
+
+      assert_that { subject.much_rails_action_class }
+        .raises(MuchRails::Action::ActionError)
+    end
+  end
+
+  class FakeController
+    def self.before_action(method_name)
+      before_actions << method_name
+    end
+
+    def self.before_actions
+      @before_actions ||= []
+    end
+
+    attr_reader :params, :head_called_with
+
+    def initialize(params)
+      @params = FakeParams.new(params)
+      self.class.before_actions.each do |before_action|
+        self.public_send(before_action)
+      end
+    end
+
+    def head(*args)
+      @head_called_with = args
+      self
+    end
+  end
+
+  class FakeParams
+    def initialize(params)
+      @params = params
+    end
+
+    def permit!
+      @permit_called = true
+      self
+    end
+
+    def [](key)
+      @params[key]
+    end
+
+    def to_h
+      raise "params haven't been permitted" unless @permit_called
+      @params
+    end
+  end
+end


### PR DESCRIPTION
This is a mix-in to turn controllers into Action controllers that
can host routes/requests served by MuchRails::Actions.

This also includes the beginnings of the MuchRails::Action::Router
which will be added to later on. This includes the constants
needed by the controller mix-in.

# Other Changes

### move error handling into MuchRails::Action::UnprocessableEntityResult

Before this was just relying on the controller to implement a
`action_errors_json` method. This was only passing tests b/c of
stubbing and test doubles.

This switches to do the error handling in the Result directly
since it is the only thing that needs it right now. This also
updates the tests to formally test the behavior with a more
accurate controller test double.

### only raise Action response exceptions in development

This adds configuration to the Railtie to only raise Action
response exceptions in development. This is nice for developers
and helps to fail fast and get useful debug info. In
non-development envs we just want to return the raw responses.
