### PR TITLE
add MuchRails::RailsRoutes

### DIFF
--- a/lib/much-rails/rails_routes.rb
+++ b/lib/much-rails/rails_routes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+# MuchRails::RailsRoutes is a Singleton object that provides Rails' URL helpers
+# and path/URL generation.
+module MuchRails; end
+class MuchRails::RailsRoutes
+  include Singleton
+  include ::Rails.application.routes.url_helpers
+
+  private
+
+  def default_url_options
+    ::Rails.application.config.action_mailer.default_url_options
+  end
+end

--- a/much-rails.gemspec
+++ b/much-rails.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = "~> 2.5"
 
   gem.add_development_dependency("assert", ["~> 2.19.0"])
+  gem.add_development_dependency("rails",  ["> 5.0", "< 7.0"])
 
   gem.add_dependency("activerecord",   ["> 5.0", "< 7.0"])
   gem.add_dependency("activesupport",  ["> 5.0", "< 7.0"])

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,4 +9,19 @@ require "pry"
 
 require "test/support/factory"
 
-# TODO: put test helpers here...
+ENV['RAILS_ENV'] ||= "test"
+
+require "rails"
+require "action_mailer/railtie"
+
+module TestRails
+  class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 6.1
+
+    config.eager_load = false
+  end
+end
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/test/unit/rails_routes_tests.rb
+++ b/test/unit/rails_routes_tests.rb
@@ -1,0 +1,26 @@
+require "assert"
+require "much-rails/rails_routes"
+
+class MuchRails::RailsRoutes
+  class UnitTests < Assert::Context
+    desc "MuchRails::RailsRoutes"
+    subject { unit_class }
+
+    let(:unit_class) { MuchRails::RailsRoutes }
+
+    should "include Singleton, Rails url helpers" do
+      assert_that(subject).includes(Singleton)
+      assert_that(subject).includes(::Rails.application.routes.url_helpers)
+    end
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject { unit_class.instance }
+
+    should "know its default URL options" do
+      assert_that(subject.__send__(:default_url_options))
+        .equals(::Rails.application.config.action_mailer.default_url_options)
+    end
+  end
+end


### PR DESCRIPTION
This is a convenience Singleton to access Rails' url helpers.
This will be used to generate paths/URLs from the Action router
which is coming.

Note: I had to bring in Rails as a development dependency so I
could test this. I did the bare minimum to configure it for
testing in the test helper.
