### PR TITLE
Fix `development?` check in Railtie

### DIFF
--- a/lib/much-rails/railtie.rb
+++ b/lib/much-rails/railtie.rb
@@ -15,7 +15,7 @@ module MuchRails
       #
       # This should be `false` in all other envs so proper HTTP response
       # statuses are returned.
-      MuchRails::Action.raise_response_exceptions = Rails.development?
+      MuchRails::Action.raise_response_exceptions = Rails.env.development?
     end
   end
 end


### PR DESCRIPTION
This fixes a missing `.env` between `Rails` and `.development?`
in `MuchRails::Railtie`.
