### PR TITLE
add Router definitions API, support HTTP method definitions

### DIFF
--- a/lib/much-rails/action/base_router.rb
+++ b/lib/much-rails/action/base_router.rb
@@ -134,16 +134,20 @@ class MuchRails::Action::BaseRouter
       end
       @set[key] = request_type
     end
-  end
 
-  class RequestType
-    attr_reader :name, :constraints_lambda
-
-    def initialize(name, constraints_lambda)
-      @name = name.to_sym
-      @constraints_lambda = constraints_lambda
+    def get(name)
+      key = name.to_sym
+      @set.fetch(key) {
+        raise(
+          ArgumentError,
+          "There is no request type named `#{name.to_sym.inspect}`."
+        )
+      }
     end
   end
+
+  RequestType = Struct.new(:name, :constraints_lambda)
+  RequestTypeAction = Struct.new(:request_type, :action_class_name)
 
   class URLSet
     def initialize(router)

--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -24,28 +24,32 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
   #  end
   # def apply_to(application_routes_draw_scope)
   #   draw_route_to = "#{controller_name}##{CONTROLLER_METHOD_NAME}"
-
-  #   definition_list.each do |definition|
-  #     definition.request_type_actions.each do |request_type, action_class_name|
+  #
+  #   definitions.each do |definition|
+  #     definition.request_type_actions.each do |request_type_action|
   #       application_routes_draw_scope.public_send(
   #         definition.http_method,
   #         definition.path,
   #         to: draw_route_to,
   #         as: definition.name,
-  #         defaults: { ACTION_CLASS_PARAM_NAME => action_class_name },
-  #         constraints: request_type.constraints_lambda,
+  #         defaults:
+  #           definition.default_params.merge({
+  #             ACTION_CLASS_PARAM_NAME => request_type_action.class_name
+  #           }),
+  #         constraints: request_type_action..constraints_lambda,
   #       )
   #     end
-
+  #
   #     if definition.has_default_action_class_name?
   #       application_routes_draw_scope.public_send(
   #         definition.http_method,
   #         definition.path,
   #         to: draw_route_to,
   #         as: definition.name,
-  #         defaults: {
-  #           ACTION_CLASS_PARAM_NAME => definition.default_action_class_name
-  #         },
+  #         defaults:
+  #           definition.default_params.merge({
+  #             ACTION_CLASS_PARAM_NAME => definition.default_action_class_name
+  #           }),
   #       )
   #     end
   #   end

--- a/test/unit/action/base_router_tests.rb
+++ b/test/unit/action/base_router_tests.rb
@@ -76,7 +76,7 @@ class MuchRails::Action::BaseRouter
       assert_that(@url_set_url_for_call.args).equals([:url1, "TEST URL ARGS"])
     end
 
-    should "allow defining request types" do
+    should "define request types" do
       proc = ->(request) {}
       request_type = subject.request_type(:type1, &proc)
       assert_that(subject.request_type_set).is_not_empty
@@ -133,7 +133,7 @@ class MuchRails::Action::BaseRouter
 
     let(:constraints_lambda1) { ->(request) {} }
 
-    should have_imeths :empty?, :add
+    should have_imeths :empty?, :add, :get
 
     should "add request types" do
       assert_that(subject).is_empty
@@ -149,6 +149,19 @@ class MuchRails::Action::BaseRouter
           .raises(ArgumentError)
       assert_that(ex.message)
         .equals("There is already a request type named `:type1`.")
+    end
+
+    should "get request types" do
+      ex =
+        assert_that{ subject.get(:type1) }.raises(ArgumentError)
+      assert_that(ex.message).equals("There is no request type named `:type1`.")
+
+      added_request_type = subject.add(:type1.to_s, constraints_lambda1)
+      request_type       = subject.get(:type1)
+      assert_that(request_type).is(added_request_type)
+
+      request_type = subject.get(:type1)
+      assert_that(request_type).is(added_request_type)
     end
   end
 
@@ -171,6 +184,32 @@ class MuchRails::Action::BaseRouter
     should "know its attributes" do
       assert_that(subject.name).equals(name1)
       assert_that(subject.constraints_lambda).equals(constraints_lambda1)
+    end
+  end
+
+  class RequestTypeActionUnitTests < UnitTests
+    desc "RequestTypeAction"
+    subject { request_type_action_class }
+
+    let(:request_type_action_class) { unit_class::RequestTypeAction }
+  end
+
+  class RequestTypeActionInitTests < RequestTypeActionUnitTests
+    desc "when init"
+    subject { request_type_action_class.new(request_type1, action_class_name1) }
+
+    let(:name1) { Factory.symbol }
+    let(:constraints_lambda1) { ->(request) {} }
+    let(:request_type1) {
+      unit_class::RequestType.new(name1, constraints_lambda1)
+    }
+    let(:action_class_name1) { Factory.string }
+
+    should have_imeths :request_type, :action_class_name
+
+    should "know its attributes" do
+      assert_that(subject.request_type).equals(request_type1)
+      assert_that(subject.action_class_name).equals(action_class_name1)
     end
   end
 

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -34,7 +34,7 @@ class MuchRails::Action::Router
 
   class URLInitTests < URLUnitTests
     desc "when init"
-    subject { url_class.new(url_name1, url_path1, router1) }
+    subject { url_class.new(router1, url_path1, url_name1) }
 
     setup do
       Assert.stub_on_call(MuchRails::RailsRoutes, :method_missing) { |call|


### PR DESCRIPTION
This is part of building out the Router definitions API. This
allows for applying the definitions to the Rails router scope which
I'll do in a coming effort.

# Other Changes

### update router handling in Action Router URL logic

This moves the router to the first positional argument since it
is required to build and handle URL names and paths.

This also adds a new `BaseURL.for` method which handles creating
unnamed URL objects from path strings as needed. This will be
used in the coming definitions API.

### add BaseRouter::RequestTypeAction and additional request type handling

This will allow  definitions to define action class names on
a per-request-type basis. The RequestTypeActions will be used
to apply request-type-specific routes before applying the default
route.