### PR TITLE
apply Router definitions to a Rails Application routes scope

### DIFF
--- a/lib/much-rails/action/base_router.rb
+++ b/lib/much-rails/action/base_router.rb
@@ -21,6 +21,7 @@ class MuchRails::Action::BaseRouter
     @definitions = []
 
     @base_url = DEFAULT_BASE_URL
+    instance_exec(&(block || proc{}))
   end
 
   def url_class
@@ -204,7 +205,12 @@ class MuchRails::Action::BaseRouter
   end
 
   RequestType = Struct.new(:name, :constraints_lambda)
-  RequestTypeAction = Struct.new(:request_type, :action_class_name)
+  RequestTypeAction =
+    Struct.new(:request_type, :class_name) do
+      def constraints_lambda
+        request_type.constraints_lambda
+      end
+    end
 
   class URLSet
     def initialize(router)

--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "much-rails/action/base_router"
-require "much-rails/rails_routes"
 
 module MuchRails; end
 module MuchRails::Action; end

--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -15,46 +15,53 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
     MuchRails::Action::Router::URL
   end
 
-  # TODO
+  attr_reader :controller_name
+
+  def initialize(name = nil, controller_name: nil, &block)
+    super(name, &block)
+
+    @controller_name = controller_name || DEFAULT_CONTROLLER_NAME
+  end
+
   # Example:
-  #  MyRouter = MuchRails::Action::Router.new { ... }
-  #  Rails.application.routes.draw do
-  #    root "/"
-  #    MyRouter.draw(self)
-  #  end
-  # def apply_to(application_routes_draw_scope)
-  #   draw_route_to = "#{controller_name}##{CONTROLLER_METHOD_NAME}"
-  #
-  #   definitions.each do |definition|
-  #     definition.request_type_actions.each do |request_type_action|
-  #       application_routes_draw_scope.public_send(
-  #         definition.http_method,
-  #         definition.path,
-  #         to: draw_route_to,
-  #         as: definition.name,
-  #         defaults:
-  #           definition.default_params.merge({
-  #             ACTION_CLASS_PARAM_NAME => request_type_action.class_name
-  #           }),
-  #         constraints: request_type_action..constraints_lambda,
-  #       )
-  #     end
-  #
-  #     if definition.has_default_action_class_name?
-  #       application_routes_draw_scope.public_send(
-  #         definition.http_method,
-  #         definition.path,
-  #         to: draw_route_to,
-  #         as: definition.name,
-  #         defaults:
-  #           definition.default_params.merge({
-  #             ACTION_CLASS_PARAM_NAME => definition.default_action_class_name
-  #           }),
-  #       )
-  #     end
+  #   MyRouter = MuchRails::Action::Router.new { ... }
+  #   Rails.application.routes.draw do
+  #     root "/"
+  #     MyRouter.draw(self)
   #   end
-  # end
-  # alias_method :draw, :apply_to
+  def apply_to(application_routes_draw_scope)
+    draw_route_to = "#{controller_name}##{CONTROLLER_METHOD_NAME}"
+
+    definitions.each do |definition|
+      definition.request_type_actions.each do |request_type_action|
+        application_routes_draw_scope.public_send(
+          definition.http_method,
+          definition.path,
+          to: draw_route_to,
+          as: definition.name,
+          defaults:
+            definition.default_params.merge({
+              ACTION_CLASS_PARAM_NAME => request_type_action.class_name
+            }),
+          constraints: request_type_action.constraints_lambda,
+        )
+      end
+
+      if definition.has_default_action_class_name?
+        application_routes_draw_scope.public_send(
+          definition.http_method,
+          definition.path,
+          to: draw_route_to,
+          as: definition.name,
+          defaults:
+            definition.default_params.merge({
+              ACTION_CLASS_PARAM_NAME => definition.default_action_class_name
+            }),
+        )
+      end
+    end
+  end
+  alias_method :draw, :apply_to
 
   class URL < MuchRails::Action::BaseRouter::BaseURL
     def path_for(*args)

--- a/lib/much-rails/railtie.rb
+++ b/lib/much-rails/railtie.rb
@@ -3,6 +3,8 @@
 module MuchRails
   class Railtie < Rails::Railtie
     initializer "much-rails-gem" do |app|
+      require "much-rails/rails_routes"
+
       # Helpers
       ActionView::Base.include(MuchRails::Layout::Helper)
 

--- a/test/unit/action/base_router_tests.rb
+++ b/test/unit/action/base_router_tests.rb
@@ -65,6 +65,11 @@ class MuchRails::Action::BaseRouter
       assert_that(@url_set_new_call.args).equals([subject])
     end
 
+    should "instance_exec any given block" do
+      router = unit_class.new { base_url "/test" }
+      assert_that(router.base_url).equals("/test")
+    end
+
     should "not implement #apply_to" do
       assert_that{ subject.apply_to("TEST SCOPE") }.raises(NotImplementedError)
     end
@@ -280,11 +285,13 @@ class MuchRails::Action::BaseRouter
     }
     let(:action_class_name1) { Factory.string }
 
-    should have_imeths :request_type, :action_class_name
+    should have_imeths :request_type, :class_name, :constraints_lambda
 
     should "know its attributes" do
       assert_that(subject.request_type).equals(request_type1)
-      assert_that(subject.action_class_name).equals(action_class_name1)
+      assert_that(subject.class_name).equals(action_class_name1)
+      assert_that(subject.constraints_lambda)
+        .equals(request_type1.constraints_lambda)
     end
   end
 


### PR DESCRIPTION
This finishes the basic routing API implementation. This takes the
definitions that were specified in the Router and applies them
appropriately to the Rails Application routes.

# Other Changes

### late-require RailsRoutes in the Railtie initializer

This needs to be super late-executed b/c Rails needs to be
initialized to set up the class. This moves the require to the
initializer to accomplish this.