### PR TITLE
fix routing to expect URL _names_ or paths

### DIFF
--- a/test/unit/action/base_router_tests.rb
+++ b/test/unit/action/base_router_tests.rb
@@ -127,13 +127,14 @@ class MuchRails::Action::BaseRouter
       request_type_class_name = Factory.string
       request_type_action =
         unit_class::RequestTypeAction.new(request_type, request_type_class_name)
-      path = Factory.url
-      url = subject.url_class.for(subject, path)
+      url_name = Factory.symbol
+      url_path = Factory.url
+      url = subject.url(url_name, url_path)
       default_class_name = Factory.string
 
       definition =
         subject.get(
-          url,
+          url_name,
           default_class_name,
           request_type_name => request_type_class_name
         )
@@ -147,7 +148,7 @@ class MuchRails::Action::BaseRouter
           request_type_actions: [request_type_action],
         )
 
-      definition = subject.post(url, default_class_name)
+      definition = subject.post(url_name, default_class_name)
       assert_that(subject.definitions.size).equals(2)
       assert_that(definition).is_instance_of(unit_class::Definition)
       assert_that(@route_definition_call.kargs)
@@ -158,18 +159,18 @@ class MuchRails::Action::BaseRouter
           request_type_actions: [],
         )
 
-      definition = subject.put(path, default_class_name)
+      definition = subject.put(url_path, default_class_name)
       assert_that(subject.definitions.size).equals(3)
       assert_that(definition).is_instance_of(unit_class::Definition)
       assert_that(@route_definition_call.kargs)
         .equals(
           http_method: :put,
-          url: url,
+          url: subject.url_class.for(subject, url_path),
           default_action_class_name: default_class_name,
           request_type_actions: [],
         )
 
-      definition = subject.patch(url, default_class_name)
+      definition = subject.patch(url_name, default_class_name)
       assert_that(subject.definitions.size).equals(4)
       assert_that(definition).is_instance_of(unit_class::Definition)
       assert_that(@route_definition_call.kargs)
@@ -180,7 +181,7 @@ class MuchRails::Action::BaseRouter
           request_type_actions: [],
         )
 
-      definition = subject.delete(url, default_class_name)
+      definition = subject.delete(url_name, default_class_name)
       assert_that(subject.definitions.size).equals(5)
       assert_that(definition).is_instance_of(unit_class::Definition)
       assert_that(@route_definition_call.kargs)
@@ -322,7 +323,7 @@ class MuchRails::Action::BaseRouter
 
     let(:router1) { unit_class.new }
 
-    should have_imeths :empty?, :add, :get, :path_for, :url_for
+    should have_imeths :empty?, :add, :fetch, :path_for, :url_for
 
     should "add URLs" do
       assert_that(subject).is_empty
@@ -337,16 +338,17 @@ class MuchRails::Action::BaseRouter
       assert_that(ex.message).equals("There is already a URL named `:url1`.")
     end
 
-    should "get URLs" do
+    should "fetch URLs" do
       ex =
-        assert_that{ subject.get(:url1) }.raises(ArgumentError)
+        assert_that{ subject.fetch(:url1) }.raises(ArgumentError)
       assert_that(ex.message).equals("There is no URL named `:url1`.")
+      assert_that(subject.fetch(:url1) { "/url1" }).equals("/url1")
 
       added_url = subject.add(:url1, Factory.url)
-      url       = subject.get(:url1)
+      url       = subject.fetch(:url1)
       assert_that(url).is(added_url)
 
-      url = subject.get(:url1.to_s)
+      url = subject.fetch(:url1.to_s)
       assert_that(url).is(added_url)
     end
 

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -46,21 +46,20 @@ class MuchRails::Action::Router
       subject.request_type(request_type_name, &request_type_proc)
       request_type_class_name = Factory.string
       path = Factory.url
-      url = subject.url_class.for(subject, path)
+      url_name = Factory.symbol
+      url_path = Factory.url
+      url = subject.url(url_name, url_path)
       default_class_name = Factory.string
 
-      url_name = Factory.symbol
-      Assert.stub(url, :name) { url_name }
-
       subject.get(
-        url,
+        url_name,
         default_class_name,
         request_type_name => request_type_class_name
       )
-      subject.post(url, default_class_name)
-      subject.put(path, default_class_name)
-      subject.patch(url, default_class_name)
-      subject.delete(url, default_class_name)
+      subject.post(url_name, default_class_name)
+      subject.put(url_path, default_class_name)
+      subject.patch(url_name, default_class_name)
+      subject.delete(url_name, default_class_name)
 
       application_routes = FakeApplicationRoutes.new
       subject.draw(application_routes)
@@ -71,7 +70,7 @@ class MuchRails::Action::Router
         { unit_class::ACTION_CLASS_PARAM_NAME => default_class_name }
 
       assert_that(application_routes.get_calls.size).equals(2)
-      assert_that(application_routes.get_calls.first.pargs).equals([path])
+      assert_that(application_routes.get_calls.first.pargs).equals([url_path])
       assert_that(application_routes.get_calls.first.kargs)
         .equals(
           to: expected_draw_route_to,
@@ -80,7 +79,7 @@ class MuchRails::Action::Router
             { unit_class::ACTION_CLASS_PARAM_NAME => request_type_class_name },
           constraints: request_type_proc,
         )
-      assert_that(application_routes.get_calls.last.pargs).equals([path])
+      assert_that(application_routes.get_calls.last.pargs).equals([url_path])
       assert_that(application_routes.get_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,
@@ -89,7 +88,7 @@ class MuchRails::Action::Router
         )
 
       assert_that(application_routes.post_calls.size).equals(1)
-      assert_that(application_routes.post_calls.last.pargs).equals([path])
+      assert_that(application_routes.post_calls.last.pargs).equals([url_path])
       assert_that(application_routes.post_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,
@@ -98,7 +97,7 @@ class MuchRails::Action::Router
         )
 
       assert_that(application_routes.put_calls.size).equals(1)
-      assert_that(application_routes.put_calls.last.pargs).equals([path])
+      assert_that(application_routes.put_calls.last.pargs).equals([url_path])
       assert_that(application_routes.put_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,
@@ -107,7 +106,7 @@ class MuchRails::Action::Router
         )
 
       assert_that(application_routes.patch_calls.size).equals(1)
-      assert_that(application_routes.patch_calls.last.pargs).equals([path])
+      assert_that(application_routes.patch_calls.last.pargs).equals([url_path])
       assert_that(application_routes.patch_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,
@@ -116,7 +115,7 @@ class MuchRails::Action::Router
         )
 
       assert_that(application_routes.delete_calls.size).equals(1)
-      assert_that(application_routes.delete_calls.last.pargs).equals([path])
+      assert_that(application_routes.delete_calls.last.pargs).equals([url_path])
       assert_that(application_routes.delete_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,


### PR DESCRIPTION
Previously, I had tested and implemented such that routing expected
either a path or a URL _object_. This is wrong. Routing should
expecct either a path or a URL _name_.

This reworks the implementation and updates the tests. This
switches to a `fetch` style API so we can easily fallback to
dynamic behavior when there is no URL for a given name. In routing,
we want to build an unnamed URL. In path generation, we want to
raise an exception to fail fast.

# Demo

Given:
![imagevkjcq](https://user-images.githubusercontent.com/82110/103448188-77c3fd00-4c5b-11eb-88cb-6fb396c2987c.jpg)

Previously (wrong):
![imagedqe7l](https://user-images.githubusercontent.com/82110/103448201-ad68e600-4c5b-11eb-8d77-9f2ce4504b73.jpg)

Now (fixed):
![image4t4hs](https://user-images.githubusercontent.com/82110/103448453-a3e17d00-4c5f-11eb-9895-5a929b05beae.jpg)
