### PR TITLE
add a bunch of tweaks/fixes after system testing in a Rails app

### DIFF
--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -34,4 +34,45 @@ require "much-rails/wrap_method"
 require "much-rails/railtie" if defined?(Rails::Railtie)
 
 module MuchRails
+  include MuchRails::Config
+
+  add_config :much_rails, method_name: :config
+  singleton_class.alias_method :configure, :configure_much_rails
+
+  class MuchRailsConfig
+    include MuchRails::Config
+
+    add_instance_config :action, method_name: :action
+    add_instance_config :layout, method_name: :layout
+
+    class ActionConfig
+      attr_accessor :sanitized_exception_classes
+      attr_accessor :raise_response_exceptions
+
+      def initialize
+        @sanitized_exception_classes = [ActiveRecord::RecordInvalid]
+        @raise_response_exceptions   = false
+      end
+
+      def raise_response_exceptions?
+        !!@raise_response_exceptions
+      end
+    end
+
+    class LayoutConfig
+      attr_accessor :full_page_title_segment_separator
+      attr_accessor :full_page_title_application_separator
+
+      # Override as desired in an initializer, e.g.:
+      #
+      # Example:
+      #   # in config/initializers/much_rails.rb
+      #   MuchRails.config.layout.full_page_title_segment_separator " / "
+      #   MuchRails.config.layout.full_page_title_application_separator " :: "
+      def initialize
+        @full_page_title_segment_separator = " - "
+        @full_page_title_application_separator = " | "
+      end
+    end
+  end
 end

--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -15,25 +15,14 @@ require "much-rails/plugin"
 require "much-rails/time"
 require "much-rails/wrap_and_call_method"
 
-# MuchRails::Action defines the common behaviors for all view action classes.
 module MuchRails; end
+
+# MuchRails::Action defines the common behaviors for all view action classes.
 module MuchRails::Action
   ForbiddenError = Class.new(StandardError)
   ActionError = Class.new(StandardError)
 
   include MuchRails::Plugin
-
-  def self.sanitized_exception_classes
-    [ActiveRecord::RecordInvalid]
-  end
-
-  def self.raise_response_exceptions=(value)
-    @raise_response_exceptions = value
-  end
-
-  def self.raise_response_exceptions?
-    !!@raise_response_exceptions
-  end
 
   plugin_included do
     include MuchRails::Config
@@ -224,7 +213,7 @@ module MuchRails::Action
       call_action_on_before_call_blocks
       catch(:halt) { instance_exec(&self.class.on_call_block) }
       call_action_on_after_call_blocks
-    rescue *MuchRails::Action.sanitized_exception_classes => ex
+    rescue *MuchRails.config.action.sanitized_exception_classes => ex
       raise(self.class.action_error_class, ex.message, ex.backtrace, cause: ex)
     end
 

--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_record"
+require "much-rails/action/controller"
 require "much-rails/action/head_result"
 require "much-rails/action/redirect_to_result"
 require "much-rails/action/render_result"

--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -107,7 +107,7 @@ module MuchRails::Action
   end
 
   plugin_instance_methods do
-    def initialize(params:, current_user:, request:)
+    def initialize(params: nil, current_user: nil, request: nil)
       @params = params.to_h.with_indifferent_access
       @current_user = current_user
       @request = request

--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -240,9 +240,19 @@ module MuchRails::Action
       throw(:halt)
     end
 
-    def render(view_model = nil, **kargs)
+    def render(*args, **kargs)
+      template, view_model =
+        [
+          args.last.kind_of?(::String) ? args.pop : nil,
+          args.pop
+        ]
+      result_kargs =
+        {
+          template: template || self.class.to_s.tableize.singularize
+        }.merge(**kargs)
+
       @much_rails_action_result =
-        MuchRails::Action::RenderResult.new(view_model, **kargs)
+        MuchRails::Action::RenderResult.new(view_model, *args, **result_kargs)
       halt
     end
 

--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -31,7 +31,7 @@ module MuchRails::Action
 
     add_config :much_rails_action
 
-    attr_reader :params, :errors
+    attr_reader :params, :current_user, :request, :errors
   end
 
   plugin_class_methods do
@@ -107,8 +107,10 @@ module MuchRails::Action
   end
 
   plugin_instance_methods do
-    def initialize(params:)
+    def initialize(params:, current_user:, request:)
       @params = params.to_h.with_indifferent_access
+      @current_user = current_user
+      @request = request
       @errors = Hash.new { |hash, key| hash[key] = [] }
     end
 

--- a/lib/much-rails/action/base_command_result.rb
+++ b/lib/much-rails/action/base_command_result.rb
@@ -2,10 +2,11 @@
 
 require "much-rails/action/base_result"
 
-# MuchRails::Action::BaseCommandResult is a base result that, when
-# executed, runs a generic controller command with some given args.
 module MuchRails; end
 module MuchRails::Action; end
+
+# MuchRails::Action::BaseCommandResult is a base result that, when
+# executed, runs a generic controller command with some given args.
 class MuchRails::Action::BaseCommandResult < MuchRails::Action::BaseResult
   attr_reader :command_name, :command_args
 

--- a/lib/much-rails/action/base_result.rb
+++ b/lib/much-rails/action/base_result.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+module MuchRails; end
+module MuchRails::Action; end
+
 # MuchRails::Action::BaseResult is a base result returned by calling
 # a view action. Its only purpose is to provide an `execute_block` that
 # defines what commands the controller should execute. This block is called
 # using `instance_exec` in the scope of the controller.
-module MuchRails; end
-module MuchRails::Action; end
 class MuchRails::Action::BaseResult
   def execute_block
     raise NotImplementedError

--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -3,10 +3,11 @@
 require "much-rails/action/router"
 require "much-rails/plugin"
 
-# MuchRails::Action::Controller defines the behaviors for controllers processing
-# MuchRails::Actions.
 module MuchRails; end
 module MuchRails::Action; end
+
+# MuchRails::Action::Controller defines the behaviors for controllers processing
+# MuchRails::Actions.
 module MuchRails::Action::Controller
   include MuchRails::Plugin
 
@@ -58,7 +59,7 @@ module MuchRails::Action::Controller
       begin
         @much_rails_action_class = much_rails_action_class_name.constantize
       rescue NameError => ex
-        if MuchRails::Action.raise_response_exceptions?
+        if MuchRails.config.action.raise_response_exceptions?
           raise(
             MuchRails::Action::ActionError,
             "No Action class defined for #{much_rails_action_class_name.inspect}.",

--- a/lib/much-rails/action/head_result.rb
+++ b/lib/much-rails/action/head_result.rb
@@ -2,10 +2,11 @@
 
 require "much-rails/action/base_command_result"
 
-# MuchRails::Views::HeadResult is a command result for the `head` controller
-# response command.
 module MuchRails; end
 module MuchRails::Action; end
+
+# MuchRails::Views::HeadResult is a command result for the `head` controller
+# response command.
 class MuchRails::Action::HeadResult < MuchRails::Action::BaseCommandResult
   def initialize(*head_args)
     super(:head, *head_args)

--- a/lib/much-rails/action/redirect_to_result.rb
+++ b/lib/much-rails/action/redirect_to_result.rb
@@ -2,10 +2,11 @@
 
 require "much-rails/action/base_command_result"
 
-# MuchRails::Action::RedirectToResult is a command result for the
-# `redirect_to` controller response command.
 module MuchRails; end
 module MuchRails::Action; end
+
+# MuchRails::Action::RedirectToResult is a command result for the
+# `redirect_to` controller response command.
 class MuchRails::Action::RedirectToResult < MuchRails::Action::BaseCommandResult
   def initialize(*redirect_to_args)
     super(:redirect_to, *redirect_to_args)

--- a/lib/much-rails/action/render_result.rb
+++ b/lib/much-rails/action/render_result.rb
@@ -17,7 +17,7 @@ class MuchRails::Action::RenderResult < MuchRails::Action::BaseResult
   # This block is called using `instance_exec` in the scope of the controller
   def execute_block
     ->(result) {
-      @view_model = result.render_view_model
+      @view = result.render_view_model
       render(**result.render_kargs)
     }
   end

--- a/lib/much-rails/action/render_result.rb
+++ b/lib/much-rails/action/render_result.rb
@@ -2,10 +2,11 @@
 
 require "much-rails/action/base_result"
 
-# MuchRails::Action::RenderResult is a result returned by calling a view
-# action that directs the controller to render a response.
 module MuchRails; end
 module MuchRails::Action; end
+
+# MuchRails::Action::RenderResult is a result returned by calling a view
+# action that directs the controller to render a response.
 class MuchRails::Action::RenderResult < MuchRails::Action::BaseResult
   attr_reader :render_view_model, :render_kargs
 

--- a/lib/much-rails/action/send_data_result.rb
+++ b/lib/much-rails/action/send_data_result.rb
@@ -2,10 +2,11 @@
 
 require "much-rails/action/base_command_result"
 
-# MuchRails::Action::SendDataResult is a command result for the `send_data`
-# controller response command.
 module MuchRails; end
 module MuchRails::Action; end
+
+# MuchRails::Action::SendDataResult is a command result for the `send_data`
+# controller response command.
 class MuchRails::Action::SendDataResult < MuchRails::Action::BaseCommandResult
   def initialize(*send_data_args)
     super(:send_data, *send_data_args)

--- a/lib/much-rails/action/send_file_result.rb
+++ b/lib/much-rails/action/send_file_result.rb
@@ -2,10 +2,11 @@
 
 require "much-rails/action/base_command_result"
 
-# MuchRails::Action::SendFileResult is a command result for the `send_file`
-# controller response command.
 module MuchRails; end
 module MuchRails::Action; end
+
+# MuchRails::Action::SendFileResult is a command result for the `send_file`
+# controller response command.
 class MuchRails::Action::SendFileResult < MuchRails::Action::BaseCommandResult
   def initialize(*send_file_args)
     super(:send_file, *send_file_args)

--- a/lib/much-rails/action/unprocessable_entity_result.rb
+++ b/lib/much-rails/action/unprocessable_entity_result.rb
@@ -2,14 +2,15 @@
 
 require "much-rails/action/base_result"
 
+module MuchRails; end
+module MuchRails::Action; end
+
 # MuchRails::Action::UnprocessableEntityResult is a result returned by
 # calling a view action that is not valid. It returns JSON with the validation
 # details.
 #
 # This result is only returned if, after validating the action, there are
 # errors. Most commonly this occurs when validating form submission params.
-module MuchRails; end
-module MuchRails::Action; end
 class MuchRails::Action::UnprocessableEntityResult <
         MuchRails::Action::BaseResult
   attr_reader :errors

--- a/lib/much-rails/call_method.rb
+++ b/lib/much-rails/call_method.rb
@@ -2,9 +2,10 @@
 
 require "much-rails/plugin"
 
+module MuchRails; end
+
 # MuchRails::CallMethod is a mix-in to implement the `call`
 # class/instance method pattern.
-module MuchRails; end
 module MuchRails::CallMethod
   include MuchRails::Plugin
 

--- a/lib/much-rails/call_method_callbacks.rb
+++ b/lib/much-rails/call_method_callbacks.rb
@@ -4,13 +4,14 @@ require "much-rails/call_method"
 require "much-rails/config"
 require "much-rails/plugin"
 
+module MuchRails; end
+
 # MuchRails::CallMethodCallbacks is a common mix-in for adding before/after
 # callback support to MuchRails::CallMethod. This is separate from the
 # MuchRails::CallMethod mix-in as it adds a bit of overhead (e.g. the
 # `much_rails_call_callbacks_config`) that may not be desired by things
 # just wanting to use the basic `MuchRails::CallMethod`. This allows opting-in
 # to callback support as needed.
-module MuchRails; end
 module MuchRails::CallMethodCallbacks
   include MuchRails::Plugin
 

--- a/lib/much-rails/change_action.rb
+++ b/lib/much-rails/change_action.rb
@@ -6,6 +6,7 @@ require "much-rails/config"
 require "much-rails/plugin"
 
 module MuchRails; end
+
 module MuchRails::ChangeAction
   Error = Class.new(StandardError)
 

--- a/lib/much-rails/change_action_result.rb
+++ b/lib/much-rails/change_action_result.rb
@@ -2,9 +2,10 @@
 
 require "much-rails/result"
 
+module MuchRails; end
+
 # MuchRails::ChangeActionResult is a Result object intended to wrap and
 # compose a MuchRails::Result.
-module MuchRails; end
 class MuchRails::ChangeActionResult
   def self.success(**kargs)
     new(MuchRails::Result.success(**kargs))

--- a/lib/much-rails/config.rb
+++ b/lib/much-rails/config.rb
@@ -1,25 +1,17 @@
 # frozen_string_literal: true
 
-require "much-rails"
 require "much-rails/plugin"
 
-# MuchRails::Config is a mix-in to implement object DSL configuration.
 module MuchRails; end
+
+# MuchRails::Config is a mix-in to implement object DSL configuration.
 module MuchRails::Config
   include MuchRails::Plugin
 
-  after_plugin_included do
-    add_config
-  end
-
   plugin_class_methods do
-    def add_config(name = nil)
-      name_prefix = name.nil? ? "" : "#{name.to_s.underscore}_"
-      config_method_name = "#{name_prefix}config"
-      config_class_name = "#{name_prefix.classify}Config"
-
-      name_suffix = name.nil? ? "" : "_#{name.to_s.underscore}"
-      configure_method_name = "configure#{name_suffix}"
+    def add_config(name = nil, method_name: nil)
+      config_method_name, config_class_name, configure_method_name =
+        much_rails_config_names(name, method_name)
 
       instance_eval(<<~RUBY, __FILE__, __LINE__ + 1)
         def #{config_method_name}
@@ -30,6 +22,34 @@ module MuchRails::Config
           yield(#{config_method_name}) if block_given?
         end
       RUBY
+    end
+
+    def add_instance_config(name = nil, method_name: nil)
+      config_method_name, config_class_name, configure_method_name =
+        much_rails_config_names(name, method_name)
+
+      instance_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+        define_method(:#{config_method_name}) do
+          @#{config_method_name} ||= self.class::#{config_class_name}.new
+        end
+
+        define_method(:#{configure_method_name}) do |&block|
+          block.call(#{config_method_name}) if block
+        end
+      RUBY
+    end
+
+    private
+
+    def much_rails_config_names(name, method_name)
+      name_prefix = name.nil? ? "" : "#{name.to_s.underscore}_"
+      config_method_name = (method_name || "#{name_prefix}config").to_s
+      config_class_name = "#{name_prefix.classify}Config"
+
+      name_suffix = name.nil? ? "" : "_#{name.to_s.underscore}"
+      configure_method_name = "configure#{name_suffix}"
+
+      [config_method_name, config_class_name, configure_method_name]
     end
   end
 end

--- a/lib/much-rails/date.rb
+++ b/lib/much-rails/date.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "much-rails"
-
 module MuchRails; end
+
 module MuchRails::Date
   InvalidError = Class.new(TypeError)
 

--- a/lib/much-rails/destroy_action.rb
+++ b/lib/much-rails/destroy_action.rb
@@ -4,6 +4,7 @@ require "much-rails/plugin"
 require "much-rails/change_action"
 
 module MuchRails; end
+
 module MuchRails::DestroyAction
   include MuchRails::Plugin
 

--- a/lib/much-rails/destroy_service.rb
+++ b/lib/much-rails/destroy_service.rb
@@ -6,6 +6,8 @@ require "much-rails/records/validate_destroy"
 require "much-rails/result"
 require "much-rails/service"
 
+module MuchRails; end
+
 # MuchRails::DestroyService is a common mix-in for all service objects that
 # destroy records.
 module MuchRails::DestroyService

--- a/lib/much-rails/input_value.rb
+++ b/lib/much-rails/input_value.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-require "much-rails"
+module MuchRails; end
 
 # MuchRails::InputValue is a utility module for dealing with input field values.
-module MuchRails;end
 module MuchRails::InputValue
   def self.strip(value)
     return if value.blank?

--- a/lib/much-rails/json.rb
+++ b/lib/much-rails/json.rb
@@ -2,9 +2,10 @@
 
 require "oj"
 
+module MuchRails; end
+
 # MuchRails::JSON is an adapter for encoding and decoding JSON values.
 # It uses Oj to do the work: https://github.com/ohler55/oj#-gem
-module MuchRails; end
 module MuchRails::JSON
   InvalidError = Class.new(TypeError)
 

--- a/lib/much-rails/layout.rb
+++ b/lib/much-rails/layout.rb
@@ -4,10 +4,11 @@ require "much-rails/layout/helper"
 require "much-rails/plugin"
 require "much-rails/view_models/breadcrumb"
 
+module MuchRails; end
+
 # MuchRails::Layout is a mix-in for view models that represent HTML rendered
 # in a layout. It adds a DSL for accumulating page titles, stylesheets and
 # javascripts.
-module MuchRails; end
 module MuchRails::Layout
   include MuchRails::Plugin
 
@@ -68,7 +69,7 @@ module MuchRails::Layout
         instance_eval(&(self.class.application_page_title || ->(_) {}))
     end
 
-    def full_page_title(segment_separator: "-", application_separator: "|")
+    def full_page_title
       @full_page_title ||=
         [
           self
@@ -76,12 +77,12 @@ module MuchRails::Layout
             .page_titles
             .reverse
             .map! { |segment| instance_eval(&segment) }
-            .join(" #{segment_separator} "),
+            .join(MuchRails.config.layout.full_page_title_segment_separator),
           application_page_title
         ]
           .map(&:presence)
           .compact
-          .join(" #{application_separator} ")
+          .join(MuchRails.config.layout.full_page_title_application_separator)
           .presence
     end
 

--- a/lib/much-rails/layout/helper.rb
+++ b/lib/much-rails/layout/helper.rb
@@ -2,6 +2,7 @@
 
 module MuchRails; end
 module MuchRails::Layout; end
+
 module MuchRails::Layout::Helper
   # This is used to render layouts. It is designed to be used in
   # the Rails layout template to render the nested layouts.

--- a/lib/much-rails/rails_routes.rb
+++ b/lib/much-rails/rails_routes.rb
@@ -2,9 +2,10 @@
 
 require "singleton"
 
+module MuchRails; end
+
 # MuchRails::RailsRoutes is a Singleton object that provides Rails' URL helpers
 # and path/URL generation.
-module MuchRails; end
 class MuchRails::RailsRoutes
   include Singleton
   include ::Rails.application.routes.url_helpers

--- a/lib/much-rails/railtie.rb
+++ b/lib/much-rails/railtie.rb
@@ -1,28 +1,31 @@
 # frozen_string_literal: true
 
-module MuchRails
-  class Railtie < Rails::Railtie
-    initializer "much-rails-gem" do |app|
-      require "much-rails/rails_routes"
+module MuchRails; end
 
-      # Helpers
-      ActionView::Base.include(MuchRails::Layout::Helper)
+class MuchRails::Railtie < Rails::Railtie
+  initializer "much-rails-gem" do |app|
+    require "much-rails/rails_routes"
 
-      require "much-rails/assets"
-      MuchRails::Assets.configure_for_rails(::Rails)
-      app.middleware.use MuchRails::Assets::Server
+    # Helpers
+    ActionView::Base.include(MuchRails::Layout::Helper)
 
+    require "much-rails/assets"
+    MuchRails::Assets.configure_for_rails(::Rails)
+    app.middleware.use MuchRails::Assets::Server
+
+    # See https://github.com/ohler55/oj/blob/master/pages/Rails.md.
+    Oj.optimize_rails
+
+    MuchResult.default_transaction_receiver = ActiveRecord::Base
+
+
+    MuchRails.configure do |config|
       # This should be `true` in development so things fail fast and give the
       # developers rich error information for debugging purposes.
       #
       # This should be `false` in all other envs so proper HTTP response
       # statuses are returned.
-      MuchRails::Action.raise_response_exceptions = Rails.env.development?
-
-      # See https://github.com/ohler55/oj/blob/master/pages/Rails.md.
-      Oj.optimize_rails
-
-      MuchResult.default_transaction_receiver = ActiveRecord::Base
+      config.action.raise_response_exceptions = Rails.env.development?
     end
   end
 end

--- a/lib/much-rails/records.rb
+++ b/lib/much-rails/records.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-module MuchRails; end
-module MuchRails::Records
-end
-
 require "much-rails/records/always_destroyable"
 require "much-rails/records/not_destroyable"
 require "much-rails/records/validate_destroy"

--- a/lib/much-rails/records/always_destroyable.rb
+++ b/lib/much-rails/records/always_destroyable.rb
@@ -3,11 +3,12 @@
 require "much-rails/plugin"
 require "much-rails/records/validate_destroy"
 
+module MuchRails; end
+module MuchRails::Records; end
+
 # MuchRails::Records::AlwaysDestroyable is a mix-in to always enable destroying
 # a record. It mixes-in MuchRails::Records::ValidateDestroy and hard-codes
 # never adding destruction error messages.
-module MuchRails; end
-module MuchRails::Records; end
 module MuchRails::Records::AlwaysDestroyable
   include MuchRails::Plugin
 

--- a/lib/much-rails/records/not_destroyable.rb
+++ b/lib/much-rails/records/not_destroyable.rb
@@ -3,11 +3,12 @@
 require "much-rails/plugin"
 require "much-rails/records/validate_destroy"
 
+module MuchRails; end
+module MuchRails::Records; end
+
 # MuchRails::Records::NotDestroyable is a mix-in to disable destroying a
 # record. It mixes-in MuchRails::Records::ValidateDestroy and hard-codes
 # a permanent destruction error message.
-module MuchRails; end
-module MuchRails::Records; end
 module MuchRails::Records::NotDestroyable
   include MuchRails::Plugin
 

--- a/lib/much-rails/records/validate_destroy.rb
+++ b/lib/much-rails/records/validate_destroy.rb
@@ -2,6 +2,9 @@
 
 require "much-rails/plugin"
 
+module MuchRails; end
+module MuchRails::Records; end
+
 # MuchRails::Records::ValidateDestroy is used to mix in custom validation
 # logic and handling in destroying records.
 #
@@ -10,8 +13,6 @@ require "much-rails/plugin"
 # #destroyable?. This check runs the custom #validate_destroy logic. If the
 # record is not destroyable, the #validate_destroy method should add
 # #destruction_error_messages.
-module MuchRails; end
-module MuchRails::Records; end
 module MuchRails::Records::ValidateDestroy
   include MuchRails::Plugin
 

--- a/lib/much-rails/view_models/breadcrumb.rb
+++ b/lib/much-rails/view_models/breadcrumb.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-require "much-rails"
-
 module MuchRails; end
+
 module MuchRails::ViewModels; end
 MuchRails::ViewModels::Breadcrumb =
   Struct.new(:name, :url) do

--- a/test/unit/action/controller_tests.rb
+++ b/test/unit/action/controller_tests.rb
@@ -73,14 +73,14 @@ module MuchRails::Action::Controller
     }
 
     should "return not found when not raising response exceptions" do
-      Assert.stub(MuchRails::Action, :raise_response_exceptions?) { false }
+      Assert.stub(MuchRails.config.action, :raise_response_exceptions?) { false }
 
       assert_that(subject.much_rails_action_class).is_nil
       assert_that(subject.head_called_with).equals([:not_found])
     end
 
     should "raise an exception when raising response exceptions" do
-      Assert.stub(MuchRails::Action, :raise_response_exceptions?) { true }
+      Assert.stub(MuchRails.config.action, :raise_response_exceptions?) { true }
 
       assert_that { subject.much_rails_action_class }
         .raises(MuchRails::Action::ActionError)

--- a/test/unit/action/render_result_tests.rb
+++ b/test/unit/action/render_result_tests.rb
@@ -26,13 +26,13 @@ class MuchRails::Action::RenderResult
       assert_that(subject.render_kargs).equals(render_kargs1)
 
       controller1.instance_exec(subject, &subject.execute_block)
-      assert_that(controller1.view_model).equals(view_model1)
+      assert_that(controller1.view).equals(view_model1)
       assert_that(controller1.render_called_with).equals(render_kargs1)
     end
   end
 
   class FakeController
-    attr_reader :view_model, :render_called_with
+    attr_reader :view, :render_called_with
 
     def render(**kargs)
       @render_called_with = kargs

--- a/test/unit/action_tests.rb
+++ b/test/unit/action_tests.rb
@@ -197,14 +197,16 @@ module MuchRails::Action
       end
     }
 
-    let(:date1) { Date.current }
-    let(:time1) { Time.current.utc }
+    let(:current_date) { Date.current }
+    let(:current_time) { Time.current }
+    let(:date1) { current_date }
+    let(:time1) { current_time.utc }
 
     let(:params) {
       {
         name: "NAME",
-        entered_on: Date.current,
-        updated_at: Time.current.utc,
+        entered_on: current_date,
+        updated_at: current_time.utc,
         active: "true"
       }
     }

--- a/test/unit/action_tests.rb
+++ b/test/unit/action_tests.rb
@@ -8,15 +8,8 @@ module MuchRails::Action
 
     let(:unit_class) { MuchRails::Action }
 
-    should have_imeths :sanitized_exception_classes
-
     should "include MuchRails::Plugin" do
       assert_that(subject).includes(MuchRails::Plugin)
-    end
-
-    should "know its attributes" do
-      assert_that(subject.sanitized_exception_classes)
-        .equals([ActiveRecord::RecordInvalid])
     end
   end
 

--- a/test/unit/action_tests.rb
+++ b/test/unit/action_tests.rb
@@ -291,8 +291,7 @@ module MuchRails::Action
         .equals(template: subject.class.to_s.tableize.singularize)
 
       receiver_class.on_call { render("some/view/template", layout: false) }
-      action =
-        receiver_class.new(params: params1, current_user: nil,request: nil)
+      action = receiver_class.new(params: params1)
       result = action.call
       assert_that(result.render_view_model).is_nil
       assert_that(result.render_kargs)
@@ -304,8 +303,7 @@ module MuchRails::Action
       receiver_class.on_call {
         render(view_model, "some/view/template", layout: false)
       }
-      action =
-        receiver_class.new(params: params1, current_user: nil,request: nil)
+      action = receiver_class.new(params: params1)
       result = action.call
       assert_that(result.render_view_model).is(view_model)
       assert_that(result.render_kargs)
@@ -317,15 +315,13 @@ module MuchRails::Action
       receiver_class.on_call {
         render(view_model, "some/view/template", template: "other/template")
       }
-      action =
-        receiver_class.new(params: params1, current_user: nil,request: nil)
+      action = receiver_class.new(params: params1)
       result = action.call
       assert_that(result.render_view_model).is(view_model)
       assert_that(result.render_kargs).equals(template: "other/template")
 
       receiver_class.on_call { render(view_model, template: "other/template") }
-      action =
-        receiver_class.new(params: params1, current_user: nil,request: nil)
+      action = receiver_class.new(params: params1)
       result = action.call
       assert_that(result.render_view_model).is(view_model)
       assert_that(result.render_kargs).equals(template: "other/template")
@@ -364,49 +360,21 @@ module MuchRails::Action
       assert_that(result.errors).equals(subject.errors)
 
       params1.delete(:name)
-      result =
-        receiver_class
-          .new(
-            params: params1,
-            current_user: current_user1,
-            request: request1,
-          )
-          .call
+      result = receiver_class.new(params: params1).call
       assert_that(result.errors[:name]).includes("can't be blank")
 
       params1[:entered_on] = "INVALID DATE"
-      result =
-        receiver_class
-          .new(
-            params: params1,
-            current_user: current_user1,
-            request: request1,
-          )
-          .call
+      result = receiver_class.new(params: params1).call
       assert_that(result.errors[:entered_on]).includes("invalid date")
 
       params1[:updated_at] = "INVALID TIME"
-      result =
-        receiver_class
-          .new(
-            params: params1,
-            current_user: current_user1,
-            request: request1,
-          )
-          .call
+      result = receiver_class.new(params: params1).call
       assert_that(result.errors[:updated_at]).includes("invalid time")
 
       params1[:validate_other_param] = true
       params1[:other_param] = [nil, ""].sample
       params1[:fail_custom_validation] = true
-      result =
-        receiver_class
-          .new(
-            params: params1,
-            current_user: current_user1,
-            request: request1,
-          )
-          .call
+      result = receiver_class.new(params: params1).call
       assert_that(result.errors[:other_param]).includes("can't be blank")
       assert_that(result.errors[:custom_validation]).includes("ERROR1")
     end

--- a/test/unit/action_tests.rb
+++ b/test/unit/action_tests.rb
@@ -157,7 +157,13 @@ module MuchRails::Action
 
   class InitTests < ReceiverTests
     desc "when init"
-    subject { receiver_class.new(params: params) }
+    subject {
+      receiver_class.new(
+        params: params1,
+        current_user: current_user1,
+        request: request1,
+      )
+    }
 
     let(:receiver_class) {
       Class.new do
@@ -202,16 +208,25 @@ module MuchRails::Action
     let(:date1) { current_date }
     let(:time1) { current_time.utc }
 
-    let(:params) {
+    let(:params1) {
       {
         name: "NAME",
         entered_on: current_date,
         updated_at: current_time.utc,
-        active: "true"
+        active: "true",
       }
     }
+    let(:current_user1) { "CURRENT USER 1"}
+    let(:request1) { "REQUEST 1"}
 
+    should have_readers :params, :current_user, :request, :errors
     should have_imeths :on_call, :valid_action?, :successful_action?
+
+    should "know its attributes" do
+      assert_that(subject.params).equals(params1.with_indifferent_access)
+      assert_that(subject.current_user).equals(current_user1)
+      assert_that(subject.request).equals(request1)
+    end
 
     should "return the expected Result" do
       result = subject.call
@@ -306,22 +321,50 @@ module MuchRails::Action
       result = subject.call
       assert_that(result.errors).equals(subject.errors)
 
-      params.delete(:name)
-      result = receiver_class.new(params: params).call
+      params1.delete(:name)
+      result =
+        receiver_class
+          .new(
+            params: params1,
+            current_user: current_user1,
+            request: request1,
+          )
+          .call
       assert_that(result.errors[:name]).includes("can't be blank")
 
-      params[:entered_on] = "INVALID DATE"
-      result = receiver_class.new(params: params).call
+      params1[:entered_on] = "INVALID DATE"
+      result =
+        receiver_class
+          .new(
+            params: params1,
+            current_user: current_user1,
+            request: request1,
+          )
+          .call
       assert_that(result.errors[:entered_on]).includes("invalid date")
 
-      params[:updated_at] = "INVALID TIME"
-      result = receiver_class.new(params: params).call
+      params1[:updated_at] = "INVALID TIME"
+      result =
+        receiver_class
+          .new(
+            params: params1,
+            current_user: current_user1,
+            request: request1,
+          )
+          .call
       assert_that(result.errors[:updated_at]).includes("invalid time")
 
-      params[:validate_other_param] = true
-      params[:other_param] = [nil, ""].sample
-      params[:fail_custom_validation] = true
-      result = receiver_class.new(params: params).call
+      params1[:validate_other_param] = true
+      params1[:other_param] = [nil, ""].sample
+      params1[:fail_custom_validation] = true
+      result =
+        receiver_class
+          .new(
+            params: params1,
+            current_user: current_user1,
+            request: request1,
+          )
+          .call
       assert_that(result.errors[:other_param]).includes("can't be blank")
       assert_that(result.errors[:custom_validation]).includes("ERROR1")
     end

--- a/test/unit/change_action_tests.rb
+++ b/test/unit/change_action_tests.rb
@@ -56,6 +56,13 @@ module MuchRails::ChangeAction
   class InitTests < ReceiverTests
     desc "when init"
     subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     setup do
       Assert.stub(subject, :any_unextracted_change_result_validation_errors?) {
@@ -75,7 +82,13 @@ module MuchRails::ChangeAction
 
   class RecordErrorsWithResultExceptionTests < InitTests
     desc "with record errors and a result exception"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     setup do
       Assert.stub(subject, :any_unextracted_change_result_validation_errors?) {
@@ -103,7 +116,13 @@ module MuchRails::ChangeAction
 
   class RecordErrorsWithNoResultExceptionTests < InitTests
     desc "with record errors and no result exception"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     setup do
       Assert.stub(subject, :any_unextracted_change_result_validation_errors?) {
@@ -128,7 +147,13 @@ module MuchRails::ChangeAction
 
   class ChangeResultMethodTests < InitTests
     desc "#change_result method"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     should "memoize and return the expected Result" do
       result = subject.change_result
@@ -151,7 +176,13 @@ module MuchRails::ChangeAction
 
   class AnyUnextractedChangeResultValidationErrorsMethodTests < ReceiverTests
     desc "#any_unextracted_change_result_validation_errors? method"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     let(:receiver_class) {
       Class.new do
@@ -171,7 +202,13 @@ module MuchRails::ChangeAction
 
   class NoValidationErrorsTests < AnyUnextractedChangeResultValidationErrorsMethodTests
     desc "with no validation errors"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     let(:receiver_class) {
       Class.new do
@@ -191,7 +228,13 @@ module MuchRails::ChangeAction
 
   class ValidationErrorsTests < AnyUnextractedChangeResultValidationErrorsMethodTests
     desc "with validation errors"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     let(:receiver_class) {
       Class.new do

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -23,7 +23,15 @@ module MuchRails::Config
       end
 
       class receiver_class::AnotherConfig
+        include MuchRails::Config
+
+        add_instance_config :sub, method_name: :sub
+
         attr_accessor :another_value
+
+        class SubConfig
+          attr_accessor :sub_value
+        end
       end
     end
 
@@ -31,6 +39,7 @@ module MuchRails::Config
       Class.new do
         include MuchRails::Config
 
+        add_config
         add_config :another
       end
     }
@@ -39,12 +48,19 @@ module MuchRails::Config
 
     should "know its attributes" do
       assert_that(subject.config).is_instance_of(subject::Config)
-      subject.configure { |config| config.value = "VALUE1" }
-      assert_that(subject.config.value).equals("VALUE1")
+      subject.configure { |config| config.value = "VALUE 1" }
+      assert_that(subject.config.value).equals("VALUE 1")
 
       assert_that(subject.another_config).is_instance_of(subject::AnotherConfig)
-      subject.configure_another { |config| config.another_value = "VALUE2" }
-      assert_that(subject.another_config.another_value).equals("VALUE2")
+      subject.configure_another { |config| config.another_value = "VALUE 2" }
+      assert_that(subject.another_config.another_value).equals("VALUE 2")
+
+      assert_that(subject.another_config.sub)
+        .is_instance_of(subject::AnotherConfig::SubConfig)
+      subject.another_config.configure_sub { |sub|
+        sub.sub_value = "VALUE 3"
+      }
+      assert_that(subject.another_config.sub.sub_value).equals("VALUE 3")
     end
   end
 end

--- a/test/unit/destroy_action_tests.rb
+++ b/test/unit/destroy_action_tests.rb
@@ -48,7 +48,13 @@ module MuchRails::DestroyAction
 
   class InitTests < ReceiverTests
     desc "when init"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     should have_imeths :destroy_result
 

--- a/test/unit/layout_tests.rb
+++ b/test/unit/layout_tests.rb
@@ -86,20 +86,6 @@ module MuchRails::Layout
         .equals("Some Resource attribute1 - Some Portal | Some App")
     end
 
-    should "know its #full_page_title given custom separators" do
-      receiver_class.application_page_title { "Some App" }
-      receiver_class.page_title { "Some Portal" }
-      receiver_class.page_title { "Some Resource #{attribute1}" }
-
-      assert_that(
-        subject
-          .full_page_title(
-            segment_separator: ".",
-            application_separator: "^")
-          )
-          .equals("Some Resource attribute1 . Some Portal ^ Some App")
-    end
-
     should "know its #breadcrumbs" do
       receiver = receiver_class.new
       assert_that(receiver.breadcrumbs).is_empty

--- a/test/unit/much-rails_tests.rb
+++ b/test/unit/much-rails_tests.rb
@@ -6,10 +6,40 @@ module MuchRails
     desc "MuchRails"
     subject { unit_class }
 
-    let(:unit_class) { Assert }
+    let(:unit_class) { MuchRails }
 
-    should "be" do
-      assert_that(unit_class).is_not_nil
+    should have_imeths :config, :configure_much_rails, :configure
+
+    should "be configured as expected" do
+      assert_that(subject.config).is_not_nil
+    end
+  end
+
+  class ConfigTests < UnitTests
+    desc ".config"
+    subject { unit_class.config }
+
+    should have_imeths :action
+
+    should "be configured as expected" do
+      assert_that(subject.action).is_not_nil
+    end
+  end
+
+  class ActionConfigTests < UnitTests
+    desc ".action"
+    subject { unit_class.config.action }
+
+    should have_accessors :sanitized_exception_classes
+    should have_accessors :raise_response_exceptions
+
+    should have_imeths :raise_response_exceptions?
+
+    should "be configured as expected" do
+      assert_that(subject.sanitized_exception_classes)
+        .equals([ActiveRecord::RecordInvalid])
+      assert_that(subject.raise_response_exceptions).is_false
+      assert_that(subject.raise_response_exceptions?).is_false
     end
   end
 end

--- a/test/unit/save_action_tests.rb
+++ b/test/unit/save_action_tests.rb
@@ -48,7 +48,13 @@ module MuchRails::SaveAction
 
   class InitTests < ReceiverTests
     desc "when init"
-    subject { receiver_class.new(params: {}) }
+    subject {
+      receiver_class.new(
+        params: {},
+        current_user: nil,
+        request: nil,
+      )
+    }
 
     should have_imeths :save_result
 


### PR DESCRIPTION
Sorry for the size and number of commits here. These are all the things I ran into while getting routing and rendering working on a test `Root::Show` Action.

# Missing features

### make Action `render` properly render view templates

This uses `.to_s.tableize.singularize` to turn the Action's class
into a path string and defaults the rendered template to that. This
means that, by default, Rails will look for templates in the same
folder structure/name as the Action.

This also updates the arguments that `render` takes so you can use
the Rails `render` API to override this default and specify an
ad-hoc template string.

### update Actions to be initialized with controller params, current_user, and request

MuchRails will expect controllers to provide these 3 pieces of data
to the Action. This updates the tests accordingly.

### make Action-rendered view models available to the template using `@view`

This is shorter and matches the spirit of the view model variable:
it is an object representation of the view like the template
(which is in the `views` folder) is a plain text representation
of the view.

### update MuchRails::Config to add instance config methods

`add_instance_config` works just like `add_config` except that
the config is accessed on instances of the receiver, not the
receiver itself. E.g.

```ruby
module MyNamespace
  include MuchRails::Config

  add_config

  class Config
    include MuchRails::Config

    add_instance_config :sub

    class SubConfig
      attr_accessor :value
    end
  end
end

MyNamespace.configure do |config|
  config.sub_config.value = "VALUE 1"
end
MyNamespace.config.sub_config.value # => "VALUE 1"
```

This also allows optionally injecting a custom method name for
your configs. Use this e.g. if you don't want the default `_config`
suffix on the receiver accessor method.

### move gem configuration to nested configs on MuchRails module

This uses the new behaviors in MuchRails::Config to setup nested
configuration objects on the MuchRails module and moves disparate
config APIs into this. This sets up `MuchRails.config`,
`MuchRails.config.action`, `MuchRails.config.layout`.

In addition this moves the layout separators from default attribute
values to _configured_ defaults that can be overridden in an
initializer.

### make Action arguments optional

This means you don't _have_ to specify all 3 kargs to build an
Action. This is especially helpful in tests when your Action
doesn't even use all kargs.

I noticed this while system testing in a real Rails app.

# Bug fixes

### require much-rails/action/controller

This require was missing so you'd get NameErrors when booting a
Rails app.

### fix a randomly failing time-related but in the Action tests

This was comparing two different instances of `Time.current` when
that wasn't intended. This moves the `Time.current` to a
memoized `let` and references that for both values.

# Style convention cleanups

### get object namespacing up to convention

We typically define the namespacing above, add an empty line, and
then add the main, namespaced object definition. This gets
inconsistent files up to convention.

# Demo

I was system testing in our test Rails app and it all worked I promise.