### PR TITLE
support Action namespacing

### DIFF
--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -46,10 +46,12 @@ module MuchRails
     add_instance_config :layout, method_name: :layout
 
     class ActionConfig
+      attr_accessor :namespace
       attr_accessor :sanitized_exception_classes
       attr_accessor :raise_response_exceptions
 
       def initialize
+        @namespace = ""
         @sanitized_exception_classes = [ActiveRecord::RecordInvalid]
         @raise_response_exceptions   = false
       end

--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -104,6 +104,14 @@ module MuchRails::Action
     def on_after_call_blocks
       much_rails_action_config.on_after_call_blocks
     end
+
+    def default_action_template_name
+      @default_action_template_name ||=
+        to_s
+          .remove(/\A#{MuchRails.config.action.namespace}/)
+          .tableize
+          .singularize
+    end
   end
 
   plugin_instance_methods do
@@ -248,7 +256,7 @@ module MuchRails::Action
         ]
       result_kargs =
         {
-          template: template || self.class.to_s.tableize.singularize
+          template: template || default_action_template_name
         }.merge(**kargs)
 
       @much_rails_action_result =
@@ -278,6 +286,10 @@ module MuchRails::Action
       @much_rails_action_result =
         MuchRails::Action::SendDataResult.new(*args)
       halt
+    end
+
+    def default_action_template_name
+      self.class.default_action_template_name
     end
   end
 

--- a/test/unit/much-rails_tests.rb
+++ b/test/unit/much-rails_tests.rb
@@ -30,12 +30,14 @@ module MuchRails
     desc ".action"
     subject { unit_class.config.action }
 
+    should have_accessors :namespace
     should have_accessors :sanitized_exception_classes
     should have_accessors :raise_response_exceptions
 
     should have_imeths :raise_response_exceptions?
 
     should "be configured as expected" do
+      assert_that(subject.namespace).equals("")
       assert_that(subject.sanitized_exception_classes)
         .equals([ActiveRecord::RecordInvalid])
       assert_that(subject.raise_response_exceptions).is_false


### PR DESCRIPTION
This allows configuring namespaces for Action classes so that
their default template name will work with Rails' view template
rendering.

By default, MuchRails will expect all Action classes to be
namespaced under ``. If a namespace is configured, e.g.
"Actions::", it then knows to remove `Actions::` from the Action
class name when building the default template name for the
Action.

This can be overridden with e.g.
`MuchRails.config.action.namespace = "Views::" to define your
Actions alongside your view templates in `app/views`.