### PR TITLE
include MuchRails::NotGiven in MuchRails

### DIFF
--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -35,6 +35,7 @@ require "much-rails/railtie" if defined?(Rails::Railtie)
 
 module MuchRails
   include MuchRails::Config
+  include MuchRails::NotGiven
 
   add_config :much_rails, method_name: :config
   singleton_class.alias_method :configure, :configure_much_rails

--- a/test/unit/much-rails_tests.rb
+++ b/test/unit/much-rails_tests.rb
@@ -11,6 +11,8 @@ module MuchRails
     should have_imeths :config, :configure_much_rails, :configure
 
     should "be configured as expected" do
+      assert_that(subject).includes(MuchRails::Config)
+      assert_that(subject).includes(MuchRails::NotGiven)
       assert_that(subject.config).is_not_nil
     end
   end


### PR DESCRIPTION
This adds an include for `MuchRails::NotGiven`, which is needed to
actually use it. I've added it to the `MuchRails` file, so other
apps can use it like `MuchRails.given?("value")`.

