### PR TITLE
draw any "unrouted" Action::Router URLs as "not found" Rails routes

### DIFF
--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -14,12 +14,17 @@ module MuchRails::Action::Controller
   mixin_included do
     attr_reader :much_rails_action_class
 
-    before_action :require_much_rails_action_class
+    before_action(
+      :require_much_rails_action_class,
+      only: MuchRails::Action::Router::CONTROLLER_CALL_ACTION_METHOD_NAME
+    )
     before_action :permit_all_much_rails_action_params
   end
 
   mixin_instance_methods do
-    define_method(MuchRails::Action::Router::CONTROLLER_METHOD_NAME) do
+    define_method(
+      MuchRails::Action::Router::CONTROLLER_CALL_ACTION_METHOD_NAME,
+    ) do
       respond_to do |format|
         format.public_send(much_rails_action_class.format) do
           result =
@@ -29,6 +34,16 @@ module MuchRails::Action::Controller
               request: request,
             )
           instance_exec(result, &result.execute_block)
+        end
+      end
+    end
+
+    define_method(
+      MuchRails::Action::Router::CONTROLLER_NOT_FOUND_METHOD_NAME,
+    ) do
+      respond_to do |format|
+        format.html do
+          head :not_found
         end
       end
     end

--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -7,7 +7,8 @@ module MuchRails::Action; end
 
 class MuchRails::Action::Router < MuchRails::Action::BaseRouter
   DEFAULT_CONTROLLER_NAME = "application"
-  CONTROLLER_METHOD_NAME = :much_rails_call_action
+  CONTROLLER_CALL_ACTION_METHOD_NAME = :much_rails_call_action
+  CONTROLLER_NOT_FOUND_METHOD_NAME = :much_rails_not_found
   ACTION_CLASS_PARAM_NAME = :much_rails_action_class_name
 
   def self.url_class
@@ -48,7 +49,8 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
   #   end
   def apply_to(application_routes_draw_scope)
     validate!
-    draw_route_to = "#{controller_name}##{CONTROLLER_METHOD_NAME}"
+    draw_url_to   = "#{controller_name}##{CONTROLLER_NOT_FOUND_METHOD_NAME}"
+    draw_route_to = "#{controller_name}##{CONTROLLER_CALL_ACTION_METHOD_NAME}"
 
     definitions.each do |definition|
       definition.request_type_actions.each do |request_type_action|
@@ -77,6 +79,12 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
             ACTION_CLASS_PARAM_NAME => definition.default_action_class_name,
           }),
       )
+    end
+
+    # Draw each URL that doesn't have a route definition so that we can generate
+    # them using MuchRails::RailsRoutes.
+    unrouted_urls.each do |url|
+      application_routes_draw_scope.get(url.path, to: draw_url_to, as: url.name)
     end
   end
   alias_method :draw, :apply_to

--- a/test/unit/action/base_router_tests.rb
+++ b/test/unit/action/base_router_tests.rb
@@ -52,7 +52,7 @@ class MuchRails::Action::BaseRouter
     should have_readers :name
     should have_readers :request_type_set, :url_set, :definitions
 
-    should have_imeths :url_class, :apply_to
+    should have_imeths :url_class, :unrouted_urls, :apply_to
     should have_imeths :path_for, :url_for
     should have_imeths :request_type
     should have_imeths :base_url, :url
@@ -62,6 +62,7 @@ class MuchRails::Action::BaseRouter
       assert_that(subject.name).is_nil
       assert_that(subject.request_type_set).is_empty
       assert_that(subject.url_set).is_empty
+      assert_that(subject.unrouted_urls).is_empty
       assert_that(subject.definitions).is_empty
       assert_that(subject.base_url).equals(unit_class::DEFAULT_BASE_URL)
       assert_that(subject.url_class).equals(unit_class.url_class)
@@ -106,6 +107,7 @@ class MuchRails::Action::BaseRouter
       assert_that(subject.url_set).is_not_empty
       assert_that(url).is_kind_of(subject.url_class)
       assert_that(@url_set_add_call.args).equals([:url1, path])
+      assert_that(subject.unrouted_urls).equals([url])
 
       ex =
         assert_that{ subject.url(:url2.to_s, Factory.url) }
@@ -338,13 +340,14 @@ class MuchRails::Action::BaseRouter
 
     let(:router1){ unit_class.new }
 
-    should have_imeths :empty?, :add, :fetch, :path_for, :url_for
+    should have_imeths :empty?, :urls, :add, :fetch, :path_for, :url_for
 
     should "add URLs" do
       assert_that(subject).is_empty
 
       url = subject.add(:url1.to_s, path = Factory.url)
       assert_that(subject).is_not_empty
+      assert_that(subject.urls).equals([url])
       assert_that(url).is_kind_of(router1.url_class)
       assert_that(@url_new_call.args).equals([router1, path, :url1])
 
@@ -472,8 +475,7 @@ class MuchRails::Action::BaseRouter
       definition1 =
         definition_class.new(
           http_method: http_method1,
-          path: url_path1,
-          name: url_name1,
+          url: url1,
           default_action_class_name: default_action_class_name1,
           request_type_actions: request_type_actions1,
           called_from: caller1,
@@ -496,8 +498,7 @@ class MuchRails::Action::BaseRouter
     subject do
       definition_class.new(
         http_method: http_method1,
-        path: url_path1,
-        name: url_name1,
+        url: url1,
         default_action_class_name: default_action_class_name1,
         request_type_actions: request_type_actions1,
         default_params: default_params1,
@@ -509,19 +510,21 @@ class MuchRails::Action::BaseRouter
       { Factory.string => Factory.string }
     end
 
-    should have_readers :http_method, :path, :name, :default_params
+    should have_readers :http_method, :url, :default_params
     should have_readers :default_action_class_name, :request_type_actions
-    should have_reader :called_from
+    should have_readers :called_from
+    should have_imeths :path, :name, :has_default_action_class_name?
 
     should "know its attributes" do
       assert_that(subject.http_method).equals(http_method1)
-      assert_that(subject.path).equals(url_path1)
-      assert_that(subject.name).equals(url_name1)
+      assert_that(subject.url).equals(url1)
       assert_that(subject.default_params).equals(default_params1)
       assert_that(subject.default_action_class_name)
         .equals(default_action_class_name1)
       assert_that(subject.request_type_actions).equals(request_type_actions1)
       assert_that(subject.called_from).equals(caller1)
+      assert_that(subject.path).equals(url_path1)
+      assert_that(subject.name).equals(url_name1)
     end
   end
 end

--- a/test/unit/action/controller_tests.rb
+++ b/test/unit/action/controller_tests.rb
@@ -44,7 +44,12 @@ module MuchRails::Action::Controller
 
     should have_readers :much_rails_action_class
 
-    should have_imeths MuchRails::Action::Router::CONTROLLER_METHOD_NAME
+    should have_imeths(
+      MuchRails::Action::Router::CONTROLLER_CALL_ACTION_METHOD_NAME,
+    )
+    should have_imeths(
+      MuchRails::Action::Router::CONTROLLER_NOT_FOUND_METHOD_NAME,
+    )
     should have_imeths :much_rails_action_class_name
     should have_imeths :much_rails_action_params
     should have_imeths :require_much_rails_action_class


### PR DESCRIPTION
This ensures their paths can be generated with e.g. `.path_for`.
Before if you defined a URL but never routed it, Rails' routes
would never be aware of its URL helpers couldn't generate it.
This switches to drawing any URLs that haven't been routed to an
action method that 404s.

I chose to detect the "unrouted" URLs and define them separately
b/c Rails ArgumentErrors if you try to define the same path/name
twice.