### PR TITLE
default Action::Controller action class format values

### DIFF
--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -9,6 +9,8 @@ module MuchRails::Action; end
 # MuchRails::Action::Controller defines the behaviors for controllers processing
 # MuchRails::Actions.
 module MuchRails::Action::Controller
+  DEFAULT_ACTION_CLASS_FORMAT = :any
+
   include MuchRails::Mixin
 
   mixin_included do
@@ -26,7 +28,7 @@ module MuchRails::Action::Controller
       MuchRails::Action::Router::CONTROLLER_CALL_ACTION_METHOD_NAME,
     ) do
       respond_to do |format|
-        format.public_send(much_rails_action_class.format) do
+        format.public_send(much_rails_action_class_format) do
           result =
             much_rails_action_class.call(
               params: much_rails_action_params,
@@ -50,6 +52,10 @@ module MuchRails::Action::Controller
 
     def much_rails_action_class_name
       "::#{params[MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME]}"
+    end
+
+    def much_rails_action_class_format
+      much_rails_action_class.format || DEFAULT_ACTION_CLASS_FORMAT
     end
 
     def much_rails_action_params


### PR DESCRIPTION
This switches to using the `:any` format if the Action class
doesn't specify a format e.g. `format :html`. This prevents a
cryptic NoMethodError trying to send `nil` to an internal Rails
controller object if no format is specified. It is better to just
default to the `any` format.

# Demo

This is the error that was previously raised with no format specified before this change:
![much-rails-error](https://user-images.githubusercontent.com/82110/104662181-dba0e980-568f-11eb-9a14-c3de4497ca74.jpg)

