### PR TITLE
Allow configuring Save and Destroy service exception handling

### DIFF
--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -46,6 +46,14 @@ module MuchRails
     add_instance_config :action, method_name: :action
     add_instance_config :layout, method_name: :layout
 
+    def add_save_service_validation_error(exception_class, &block)
+      MuchRails::SaveService::ValidationErrors.add(exception_class, &block)
+    end
+
+    def add_destroy_service_validation_error(exception_class, &block)
+      MuchRails::DestroyService::ValidationErrors.add(exception_class, &block)
+    end
+
     class ActionConfig
       attr_accessor :namespace
       attr_accessor :sanitized_exception_classes

--- a/lib/much-rails/destroy_service.rb
+++ b/lib/much-rails/destroy_service.rb
@@ -18,7 +18,7 @@ module MuchRails::DestroyService
 
     around_call do |receiver|
       receiver.call
-    rescue MuchRails::Records::ValidateDestroy::DestructionInvalid => ex
+    rescue MuchRails::Records::DestructionInvalid => ex
       set_the_return_value_for_the_call_method(
         MuchRails::Result.failure(
           exception: ex,

--- a/lib/much-rails/destroy_service.rb
+++ b/lib/much-rails/destroy_service.rb
@@ -21,8 +21,10 @@ module MuchRails::DestroyService
     rescue MuchRails::Records::DestructionInvalid => ex
       set_the_return_value_for_the_call_method(
         MuchRails::Result.failure(
+          record: ex.record,
           exception: ex,
-          validation_errors: ex&.destruction_errors.to_h,
+          validation_errors: ex.errors.to_h,
+          validation_error_messages: ex.error_full_messages.to_a,
         ),
       )
     end

--- a/lib/much-rails/destroy_service.rb
+++ b/lib/much-rails/destroy_service.rb
@@ -44,7 +44,7 @@ module MuchRails::DestroyService
           .new
           .tap do |e|
             e.add(MuchRails::Records::DestructionInvalid) do |ex|
-              MuchRails::Result.failure(
+              MuchRails::DestroyService::FailureResult.new(
                 record: ex.record,
                 exception: ex,
                 validation_errors: ex.errors.to_h,
@@ -52,6 +52,16 @@ module MuchRails::DestroyService
               )
             end
           end
+    end
+  end
+
+  module FailureResult
+    def self.new(exception:, validation_errors:, **kargs)
+      MuchResult.failure(
+        exception: exception,
+        validation_errors: validation_errors,
+        **kargs,
+      )
     end
   end
 end

--- a/lib/much-rails/railtie.rb
+++ b/lib/much-rails/railtie.rb
@@ -27,6 +27,13 @@ class MuchRails::Railtie < Rails::Railtie
       # This should be `false` in all other envs so proper HTTP response
       # statuses are returned.
       config.action.raise_response_exceptions = Rails.env.development?
+
+      config.save_service_validation_error_exception_classes = [
+        ActiveRecord::RecordInvalid,
+      ]
+      config.destroy_service_validation_error_exception_classes = [
+        MuchRails::Records::DestructionInvalid,
+      ]
     end
   end
 end

--- a/lib/much-rails/records/validate_destroy.rb
+++ b/lib/much-rails/records/validate_destroy.rb
@@ -33,7 +33,7 @@ module MuchRails::Records::ValidateDestroy
 
     def destroy!(as: :base, validate: true)
       if validate && !destroyable?
-        raise DestructionInvalid.new(self, field_name: as)
+        raise MuchRails::Records::DestructionInvalid.new(self, field_name: as)
       end
 
       # `_raise_record_not_destroyed` is from ActiveRecord. This logic was
@@ -61,22 +61,22 @@ module MuchRails::Records::ValidateDestroy
       raise NotImplementedError
     end
   end
+end
 
-  class DestructionInvalid < StandardError
-    attr_reader :record, :destruction_errors
+class MuchRails::Records::DestructionInvalid < StandardError
+  attr_reader :record, :destruction_errors
 
-    def initialize(record = nil, field_name: :base)
-      super(record&.destruction_error_messages.to_a.join("\n"))
+  def initialize(record = nil, field_name: :base)
+    super(record&.destruction_error_messages.to_a.join("\n"))
 
-      @record = record
+    @record = record
 
-      messages = record&.destruction_error_messages.to_a
-      @destruction_errors =
-        if messages.any?
-          { field_name.to_sym => messages }
-        else
-          {}
-        end
-    end
+    messages = record&.destruction_error_messages.to_a
+    @destruction_errors =
+      if messages.any?
+        { field_name.to_sym => messages }
+      else
+        {}
+      end
   end
 end

--- a/lib/much-rails/save_service.rb
+++ b/lib/much-rails/save_service.rb
@@ -44,7 +44,7 @@ module MuchRails::SaveService
           .new
           .tap do |e|
             e.add(ActiveRecord::RecordInvalid) do |ex|
-              MuchRails::Result.failure(
+              MuchRails::SaveService::FailureResult.new(
                 record: ex.record,
                 exception: ex,
                 validation_errors: ex.record&.errors.to_h,
@@ -53,6 +53,16 @@ module MuchRails::SaveService
               )
             end
           end
+    end
+  end
+
+  module FailureResult
+    def self.new(exception:, validation_errors:, **kargs)
+      MuchResult.failure(
+        exception: exception,
+        validation_errors: validation_errors,
+        **kargs,
+      )
     end
   end
 end

--- a/lib/much-rails/service_validation_errors.rb
+++ b/lib/much-rails/service_validation_errors.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module MuchRails; end
+
+class MuchRails::ServiceValidationErrors
+  attr_reader :hash
+
+  def initialize
+    @hash = {}
+  end
+
+  def add(exception_class, &block)
+    unless exception_class < Exception
+      raise(ArgumentError, "#{exception_class} is not an Exception")
+    end
+
+    @hash[exception_class] = block
+  end
+
+  def exception_classes
+    @hash.keys
+  end
+
+  def result_for(ex)
+    result_proc = nil
+    exception_class = ex.class
+    loop do
+      result_proc = @hash[exception_class]
+      break unless result_proc.nil?
+
+      exception_class =
+        if exception_class.superclass.nil?
+          raise ArgumentError, "#{ex.class} hasn't been configured"
+        else
+          exception_class.superclass
+        end
+    end
+
+    result_proc.call(ex)
+  end
+end

--- a/test/unit/destroy_service_tests.rb
+++ b/test/unit/destroy_service_tests.rb
@@ -185,6 +185,51 @@ module MuchRails::DestroyService
     end
   end
 
+  class FailureResultTests < UnitTests
+    desc "FailureResult"
+    subject{ unit_class::FailureResult }
+
+    setup do
+      Assert.stub_tap_on_call(MuchResult, :failure) do |_, call|
+        @much_result_failure_call = call
+      end
+    end
+
+    let(:exception){ StandardError.new(Factory.string) }
+    let(:validation_errors){ { Factory.symbol => Factory.string } }
+    let(:custom_value){ Factory.string }
+
+    should have_imeths :new
+
+    should "use MuchResult.failure to build a result" do
+      result =
+        subject.new(
+          exception: exception,
+          validation_errors: validation_errors,
+          custom: custom_value,
+        )
+      assert_that(result.failure?).is_true
+      assert_that(@much_result_failure_call.kargs)
+        .equals(
+          exception: exception,
+          validation_errors: validation_errors,
+          custom: custom_value,
+        )
+    end
+
+    should "raise an error without an exception or validation errors" do
+      assert_that{
+        subject.new(validation_errors: validation_errors)
+      }.raises(ArgumentError)
+    end
+
+    should "raise an error without an exception or validation errors" do
+      assert_that{
+        subject.new(exception: exception)
+      }.raises(ArgumentError)
+    end
+  end
+
   class FakeRecord
     def destruction_error_messages
       ["ERROR1", "ERROR2"]

--- a/test/unit/destroy_service_tests.rb
+++ b/test/unit/destroy_service_tests.rb
@@ -45,14 +45,12 @@ module MuchRails::DestroyService
   end
 
   class DestructionInvalidErrorSetupTests < ReceiverTests
-    desc "with a MuchRails::Records::ValidateDestroy::DestructionInvalid error"
+    desc "with a MuchRails::Records::DestructionInvalid error"
     setup do
       Assert.stub(exception, :record){ record }
     end
 
-    let(:exception) do
-      MuchRails::Records::ValidateDestroy::DestructionInvalid.new
-    end
+    let(:exception){ MuchRails::Records::DestructionInvalid.new }
   end
 
   class ExceptionWithDestructionErrorMessagesTests <

--- a/test/unit/destroy_service_tests.rb
+++ b/test/unit/destroy_service_tests.rb
@@ -63,8 +63,11 @@ module MuchRails::DestroyService
       result = subject.call(exception: exception)
 
       assert_that(result.failure?).is_true
+      assert_that(result.record).is(record)
       assert_that(result.exception).equals(exception)
-      assert_that(result.validation_errors).equals(exception.destruction_errors)
+      assert_that(result.validation_errors).equals(exception.errors)
+      assert_that(result.validation_error_messages)
+        .equals(exception.error_full_messages)
     end
   end
 
@@ -79,8 +82,11 @@ module MuchRails::DestroyService
       result = subject.call(exception: exception)
 
       assert_that(result.failure?).is_true
+      assert_that(result.record).is_nil
       assert_that(result.exception).equals(exception)
-      assert_that(result.validation_errors).equals({})
+      assert_that(result.validation_errors).equals(exception.errors)
+      assert_that(result.validation_error_messages)
+        .equals(exception.error_full_messages)
     end
   end
 

--- a/test/unit/destroy_service_tests.rb
+++ b/test/unit/destroy_service_tests.rb
@@ -44,49 +44,144 @@ module MuchRails::DestroyService
     end
   end
 
-  class DestructionInvalidErrorSetupTests < ReceiverTests
-    desc "with a MuchRails::Records::DestructionInvalid error"
+  class ReceiverInitTests < ReceiverTests
+    desc "when init"
+    subject{ receiver_class.new(exception: exception) }
+
+    let(:exception){ nil }
+  end
+
+  class ReceiverInitAroundCallCallbackTests < ReceiverInitTests
+    desc "around_call callback"
     setup do
-      Assert.stub(exception, :record){ record }
+      Assert.stub(
+        MuchRails::DestroyService::ValidationErrors,
+        :exception_classes,
+      ){ exception_classes }
+      Assert.stub_on_call(
+        MuchRails::DestroyService::ValidationErrors,
+        :result_for,
+      ) do |call|
+        @result_for_call = call
+        validation_error_result
+      end
     end
 
-    let(:exception){ MuchRails::Records::DestructionInvalid.new }
-  end
+    let(:exception){ exceptions.sample }
+    let(:exceptions) do
+      [
+        RuntimeError.new(Factory.string),
+        ArgumentError.new(Factory.string),
+        MuchRails::Records::DestructionInvalid.new(FakeRecord.new),
+      ]
+    end
+    let(:exception_classes){ exceptions.map(&:class) }
+    let(:validation_error_result) do
+      MuchResult.failure(error: result_error_message)
+    end
+    let(:result_error_message){ Factory.string }
 
-  class ExceptionWithDestructionErrorMessagesTests <
-          DestructionInvalidErrorSetupTests
-    desc "with an exception record that has destruction_error_messages"
-
-    let(:record){ @fake_record ||= FakeRecord.new }
-
-    should "return a failure result with the exception and validation_errors" do
-      result = subject.call(exception: exception)
+    should "rescue raised exceptions and "\
+           "use the ValidationErrors to build a result" do
+      result = subject.call
 
       assert_that(result.failure?).is_true
-      assert_that(result.record).is(record)
-      assert_that(result.exception).equals(exception)
-      assert_that(result.validation_errors).equals(exception.errors)
-      assert_that(result.validation_error_messages)
-        .equals(exception.error_full_messages)
+      assert_that(result.error).equals(result_error_message)
     end
   end
 
-  class ExceptionWithoutDestructionErrorMessagesTests <
-          DestructionInvalidErrorSetupTests
-    desc "with an exception record that has no destruction_error_messages"
+  class ValidationErrorsTests < UnitTests
+    desc "ValidationErrors"
+    subject{ unit_class::ValidationErrors }
 
-    let(:record){ nil }
+    should have_imeths :add, :exception_classes, :result_for
+    should have_imeths :service_validation_errors
 
-    should "return a failure result with the exception and empty "\
-           "validation_errors" do
-      result = subject.call(exception: exception)
+    should "know its ServiceValidationErrors" do
+      assert_that(subject.service_validation_errors)
+        .is_an_instance_of(MuchRails::ServiceValidationErrors)
+      assert_that(subject.service_validation_errors.exception_classes)
+        .includes(MuchRails::Records::DestructionInvalid)
+    end
+  end
+
+  class ValidationErrorsAddTests < ValidationErrorsTests
+    desc ".add"
+
+    setup do
+      Assert.stub_on_call(subject.service_validation_errors, :add) do |call|
+        @add_call = call
+      end
+    end
+
+    let(:exception_class){ StandardError }
+    let(:block){ proc{ MuchResult.failure } }
+
+    should "call #add on its ServiceValidationErrors" do
+      subject.add(exception_class, &block)
+      assert_that(@add_call.args).equals([exception_class])
+      assert_that(@add_call.block).is(block)
+    end
+  end
+
+  class ValidationErrorsExceptionClassesTests < ValidationErrorsTests
+    desc ".exception_classes"
+
+    setup do
+      Assert.stub(
+        subject.service_validation_errors,
+        :exception_classes,
+      ){ exception_classes }
+    end
+
+    let(:exception_classes) do
+      [
+        StandardError,
+        ArgumentError,
+      ]
+    end
+
+    should "call #exception_classes on its ServiceValidationErrors" do
+      assert_that(subject.exception_classes).is(exception_classes)
+    end
+  end
+
+  class ValidationErrorsResultForTests < ValidationErrorsTests
+    desc ".result_for"
+
+    setup do
+      Assert.stub_on_call(
+        subject.service_validation_errors,
+        :result_for,
+      ) do |call|
+        @result_for_call = call
+        result_for_result
+      end
+    end
+
+    let(:exception){ StandardError.new(Factory.string) }
+    let(:result_for_result){ MuchResult.failure }
+
+    should "call #result_for on its ServiceValidationErrors" do
+      assert_that(subject.result_for(exception)).is(result_for_result)
+      assert_that(@result_for_call.args).equals([exception])
+    end
+  end
+
+  class ValidationErrorsResultForDestructionInvalidTests < ValidationErrorsTests
+    desc "when .result_for is passed an MuchRails::Records::DestructionInvalid"
+
+    let(:exception){ MuchRails::Records::DestructionInvalid.new(record) }
+    let(:record){ FakeRecord.new }
+
+    should "return a failure result with the record and validation errors" do
+      result = subject.result_for(exception)
 
       assert_that(result.failure?).is_true
-      assert_that(result.record).is_nil
       assert_that(result.exception).equals(exception)
-      assert_that(result.validation_errors).equals(exception.errors)
+      assert_that(result.validation_errors).equals(exception.errors.to_h)
       assert_that(result.validation_error_messages)
-        .equals(exception.error_full_messages)
+        .equals(exception.error_full_messages.to_a)
     end
   end
 

--- a/test/unit/much-rails_tests.rb
+++ b/test/unit/much-rails_tests.rb
@@ -23,10 +23,51 @@ module MuchRails
     desc ".config"
     subject{ unit_class.config }
 
-    should have_imeths :action
+    should have_imeths :action, :layout
+    should have_imeths :add_save_service_validation_error
+    should have_imeths :add_destroy_service_validation_error
 
     should "be configured as expected" do
       assert_that(subject.action).is_not_nil
+      assert_that(subject.layout).is_not_nil
+    end
+  end
+
+  class ConfigServiceValidationErrorTests < ConfigTests
+    setup do
+      Assert.stub_on_call(
+        MuchRails::SaveService::ValidationErrors,
+        :add,
+      ) do |call|
+        @save_service_validation_errors_add_call = call
+      end
+      Assert.stub_on_call(
+        MuchRails::DestroyService::ValidationErrors,
+        :add,
+      ) do |call|
+        @destroy_service_validation_errors_add_call = call
+      end
+    end
+
+    let(:exception_class){ StandardError }
+    let(:block){ proc{ MuchResult.failure } }
+
+    should "know how to add an exception class "\
+           "to the save service validation errors" do
+      subject.add_save_service_validation_error(exception_class, &block)
+      assert_that(@save_service_validation_errors_add_call.args)
+        .equals([exception_class])
+      assert_that(@save_service_validation_errors_add_call.block)
+        .is(block)
+    end
+
+    should "know how to add an exception class "\
+           "to the destroy service validation errors" do
+      subject.add_destroy_service_validation_error(exception_class, &block)
+      assert_that(@destroy_service_validation_errors_add_call.args)
+        .equals([exception_class])
+      assert_that(@destroy_service_validation_errors_add_call.block)
+        .is(block)
     end
   end
 

--- a/test/unit/records/always_destroyable_tests.rb
+++ b/test/unit/records/always_destroyable_tests.rb
@@ -34,7 +34,7 @@ module MuchRails::Records::AlwaysDestroyable
 
       assert_that(subject.destroy).is_true
 
-      # won't raise MuchRails::Records::ValidateDestroy::DestructionInvalid
+      # won't raise MuchRails::Records::DestructionInvalid
       subject.destroy!
 
       assert_that(subject.destroyable?).is_true

--- a/test/unit/records/not_destroyable_tests.rb
+++ b/test/unit/records/not_destroyable_tests.rb
@@ -32,7 +32,7 @@ module MuchRails::Records::NotDestroyable
       assert_that(subject.destroy).is_false
 
       assert_that(->{ subject.destroy! })
-        .raises(MuchRails::Records::ValidateDestroy::DestructionInvalid)
+        .raises(MuchRails::Records::DestructionInvalid)
 
       assert_that(subject.destroyable?).is_false
     end

--- a/test/unit/records/validate_destroy_tests.rb
+++ b/test/unit/records/validate_destroy_tests.rb
@@ -65,14 +65,14 @@ module MuchRails::Records::ValidateDestroy
           .raises(MuchRails::Records::DestructionInvalid)
       assert_that(exception.message)
         .equals("TEST DESTRUCTION ERROR1\nTEST DESTRUCTION ERROR2")
-      assert_that(exception.destruction_errors)
+      assert_that(exception.errors)
         .equals(base: subject.destruction_error_messages.to_a)
       assert_that(subject.super_destroy_called).is_true
 
       exception =
         assert_that(->{ subject.destroy!(as: :thing) })
           .raises(MuchRails::Records::DestructionInvalid)
-      assert_that(exception.destruction_errors)
+      assert_that(exception.errors)
         .equals(thing: subject.destruction_error_messages.to_a)
 
       subject.super_destroy_called = nil
@@ -138,9 +138,85 @@ module MuchRails::Records::ValidateDestroy
     end
   end
 
+  class DestructionInvalidTests < UnitTests
+    desc "MuchRails::Records::DestructionInvalid"
+    subject{ exception_class }
+
+    let(:exception_class){ MuchRails::Records::DestructionInvalid }
+
+    let(:record){ FakeRecordClass.new }
+
+    should "be configured as expected" do
+      assert_that(subject < StandardError).is_true
+    end
+  end
+
+  class DestructionInvalidInitTests < DestructionInvalidTests
+    desc "when init"
+    subject{ exception_class.new(record) }
+
+    should have_readers :record, :errors, :error_full_messages
+
+    should "know its attributes when destruction errors exist" do
+      record.destruction_errors_exist = true
+      record.validate_destroy
+
+      assert_that(subject.message)
+        .equals(record.destruction_error_messages.to_a.join("\n"))
+      assert_that(subject.record).is(record)
+      assert_that(subject.errors).equals(
+        base: record.destruction_error_messages.to_a,
+      )
+      assert_that(subject.error_full_messages)
+        .equals(record.destruction_error_messages.to_a)
+    end
+
+    should "know its attributes when destruction errors don't exist" do
+      assert_that(subject.message).equals("")
+      assert_that(subject.record).is(record)
+      assert_that(subject.errors).equals({})
+      assert_that(subject.error_full_messages).equals([])
+    end
+  end
+
+  class DestructionInvalidInitWithFieldNameTests < DestructionInvalidTests
+    desc "when init with a field name"
+    subject{ exception_class.new(record, field_name: field_name) }
+
+    let(:field_name){ Factory.string }
+
+    should "know its attributes when destruction errors exist" do
+      record.destruction_errors_exist = true
+      record.validate_destroy
+
+      assert_that(subject.message)
+        .equals(record.destruction_error_messages.to_a.join("\n"))
+      assert_that(subject.record).is(record)
+      assert_that(subject.errors).equals(
+        field_name.to_sym => record.destruction_error_messages.to_a,
+      )
+      assert_that(subject.error_full_messages)
+        .equals(
+          record
+            .destruction_error_messages
+            .map do |m|
+              ActiveModel::Error.new(record, field_name, m).full_message
+            end,
+        )
+    end
+
+    should "know its attributes when destruction errors don't exist" do
+      assert_that(subject.message).equals("")
+      assert_that(subject.record).is(record)
+      assert_that(subject.errors).equals({})
+      assert_that(subject.error_full_messages).equals([])
+    end
+  end
+
   require "active_record"
 
   class FakeRecordBaseClass
+    extend ActiveRecord::Translation
     # Include ActiveRecord::Persistence to test the `destroy!` logic
     # (the `_raise_record_not_destroyed` method) that we had to re-implement in
     # the MuchRails::Records::ValidateDestroy.
@@ -149,6 +225,10 @@ module MuchRails::Records::ValidateDestroy
     attr_accessor :super_destroy_called
 
     attr_accessor :destruction_errors_exist
+
+    def self.base_class?
+      true
+    end
 
     def destroy
       @super_destroy_called = true

--- a/test/unit/records/validate_destroy_tests.rb
+++ b/test/unit/records/validate_destroy_tests.rb
@@ -62,7 +62,7 @@ module MuchRails::Records::ValidateDestroy
 
       exception =
         assert_that(->{ subject.destroy! })
-          .raises(MuchRails::Records::ValidateDestroy::DestructionInvalid)
+          .raises(MuchRails::Records::DestructionInvalid)
       assert_that(exception.message)
         .equals("TEST DESTRUCTION ERROR1\nTEST DESTRUCTION ERROR2")
       assert_that(exception.destruction_errors)
@@ -71,7 +71,7 @@ module MuchRails::Records::ValidateDestroy
 
       exception =
         assert_that(->{ subject.destroy!(as: :thing) })
-          .raises(MuchRails::Records::ValidateDestroy::DestructionInvalid)
+          .raises(MuchRails::Records::DestructionInvalid)
       assert_that(exception.destruction_errors)
         .equals(thing: subject.destruction_error_messages.to_a)
 

--- a/test/unit/save_service_tests.rb
+++ b/test/unit/save_service_tests.rb
@@ -44,49 +44,164 @@ module MuchRails::SaveService
     end
   end
 
-  class RecordInvalidErrorSetupTests < ReceiverTests
-    desc "with an ActiveRecord::RecordInvalid error"
-    setup do
-      Assert.stub(exception, :record){ record }
-    end
+  class ReceiverInitTests < ReceiverTests
+    desc "when init"
+    subject{ receiver_class.new(exception: exception) }
 
-    let(:exception){ ActiveRecord::RecordInvalid.new }
+    let(:exception){ nil }
   end
 
-  class ExceptionWithRecordErrorsTests < RecordInvalidErrorSetupTests
-    desc "with an exception that has record errors"
+  class ReceiverInitAroundCallCallbackTests < ReceiverInitTests
+    desc "around_call callback"
+    setup do
+      Assert.stub(
+        MuchRails::SaveService::ValidationErrors,
+        :exception_classes,
+      ){ exception_classes }
+      Assert.stub_on_call(
+        MuchRails::SaveService::ValidationErrors,
+        :result_for,
+      ) do |call|
+        @result_for_call = call
+        validation_error_result
+      end
+    end
 
-    let(:record){ @fake_record ||= FakeRecord.new }
+    let(:exception){ exceptions.sample }
+    let(:exceptions) do
+      [
+        RuntimeError.new(Factory.string),
+        ArgumentError.new(Factory.string),
+        ActiveRecord::RecordInvalid.new(FakeRecord.new),
+      ]
+    end
+    let(:exception_classes){ exceptions.map(&:class) }
+    let(:validation_error_result) do
+      MuchResult.failure(error: result_error_message)
+    end
+    let(:result_error_message){ Factory.string }
 
-    should "return a failure result with the exception and record errors" do
-      result = subject.call(exception: exception)
+    should "rescue raised exceptions and "\
+           "use the ValidationErrors to build a result" do
+      result = subject.call
+
+      assert_that(result.failure?).is_true
+      assert_that(result.error).equals(result_error_message)
+    end
+  end
+
+  class ValidationErrorsTests < UnitTests
+    desc "ValidationErrors"
+    subject{ unit_class::ValidationErrors }
+
+    should have_imeths :add, :exception_classes, :result_for
+    should have_imeths :service_validation_errors
+
+    should "know its ServiceValidationErrors" do
+      assert_that(subject.service_validation_errors)
+        .is_an_instance_of(MuchRails::ServiceValidationErrors)
+      assert_that(subject.service_validation_errors.exception_classes)
+        .includes(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  class ValidationErrorsAddTests < ValidationErrorsTests
+    desc ".add"
+
+    setup do
+      Assert.stub_on_call(subject.service_validation_errors, :add) do |call|
+        @add_call = call
+      end
+    end
+
+    let(:exception_class){ StandardError }
+    let(:block){ proc{ MuchResult.failure } }
+
+    should "call #add on its ServiceValidationErrors" do
+      subject.add(exception_class, &block)
+      assert_that(@add_call.args).equals([exception_class])
+      assert_that(@add_call.block).is(block)
+    end
+  end
+
+  class ValidationErrorsExceptionClassesTests < ValidationErrorsTests
+    desc ".exception_classes"
+
+    setup do
+      Assert.stub(
+        subject.service_validation_errors,
+        :exception_classes,
+      ){ exception_classes }
+    end
+
+    let(:exception_classes) do
+      [
+        StandardError,
+        ArgumentError,
+      ]
+    end
+
+    should "call #exception_classes on its ServiceValidationErrors" do
+      assert_that(subject.exception_classes).is(exception_classes)
+    end
+  end
+
+  class ValidationErrorsResultForTests < ValidationErrorsTests
+    desc ".result_for"
+
+    setup do
+      Assert.stub_on_call(
+        subject.service_validation_errors,
+        :result_for,
+      ) do |call|
+        @result_for_call = call
+        result_for_result
+      end
+    end
+
+    let(:exception){ StandardError.new(Factory.string) }
+    let(:result_for_result){ MuchResult.failure }
+
+    should "call #result_for on its ServiceValidationErrors" do
+      assert_that(subject.result_for(exception)).is(result_for_result)
+      assert_that(@result_for_call.args).equals([exception])
+    end
+  end
+
+  class ValidationErrorsResultForRecordInvalidTests < ValidationErrorsTests
+    desc "when .result_for is passed an ActiveRecord::RecordInvalid"
+
+    let(:exception){ ActiveRecord::RecordInvalid.new(record) }
+    let(:record){ FakeRecord.new }
+
+    let(:no_record_exception){ ActiveRecord::RecordInvalid.new }
+
+    should "return a failure result with the record and validation errors" do
+      result = subject.result_for(exception)
 
       assert_that(result.failure?).is_true
       assert_that(result.exception).equals(exception)
-      assert_that(result.validation_errors)
-        .equals(some_field: %w[ERROR1 ERROR2])
+      assert_that(result.validation_errors).equals(record.errors.to_h)
       assert_that(result.validation_error_messages)
-        .equals(["some_field ERROR1", "some_field ERROR2"])
+        .equals(record.errors.full_messages.to_a)
     end
-  end
-
-  class ExceptionWithoutRecordErrorsTests < RecordInvalidErrorSetupTests
-    desc "with an exception that has no record errors"
-
-    let(:record){ nil }
 
     should "return a failure result with the exception and empty "\
            "record errors" do
-      result = subject.call(exception: exception)
+      result = subject.result_for(no_record_exception)
 
       assert_that(result.failure?).is_true
-      assert_that(result.exception).equals(exception)
+      assert_that(result.exception).equals(no_record_exception)
       assert_that(result.validation_errors).equals({})
       assert_that(result.validation_error_messages).equals([])
     end
   end
 
   class FakeRecord
+    def self.i18n_scope
+      "fake_record"
+    end
+
     def errors
       Errors.new
     end

--- a/test/unit/save_service_tests.rb
+++ b/test/unit/save_service_tests.rb
@@ -197,6 +197,51 @@ module MuchRails::SaveService
     end
   end
 
+  class FailureResultTests < UnitTests
+    desc "FailureResult"
+    subject{ unit_class::FailureResult }
+
+    setup do
+      Assert.stub_tap_on_call(MuchResult, :failure) do |_, call|
+        @much_result_failure_call = call
+      end
+    end
+
+    let(:exception){ StandardError.new(Factory.string) }
+    let(:validation_errors){ { Factory.symbol => Factory.string } }
+    let(:custom_value){ Factory.string }
+
+    should have_imeths :new
+
+    should "use MuchResult.failure to build a result" do
+      result =
+        subject.new(
+          exception: exception,
+          validation_errors: validation_errors,
+          custom: custom_value,
+        )
+      assert_that(result.failure?).is_true
+      assert_that(@much_result_failure_call.kargs)
+        .equals(
+          exception: exception,
+          validation_errors: validation_errors,
+          custom: custom_value,
+        )
+    end
+
+    should "raise an error without an exception or validation errors" do
+      assert_that{
+        subject.new(validation_errors: validation_errors)
+      }.raises(ArgumentError)
+    end
+
+    should "raise an error without an exception or validation errors" do
+      assert_that{
+        subject.new(exception: exception)
+      }.raises(ArgumentError)
+    end
+  end
+
   class FakeRecord
     def self.i18n_scope
       "fake_record"

--- a/test/unit/service_validation_errors_tests.rb
+++ b/test/unit/service_validation_errors_tests.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+class MuchRails::ServiceValidationErrors
+  class UnitTests < Assert::Context
+    desc "MuchRails::ServiceValidationErrors"
+    subject{ unit_class }
+
+    let(:unit_class){ MuchRails::ServiceValidationErrors }
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    subject{ unit_class.new }
+
+    should have_readers :hash
+    should have_imeths :add, :exception_classes, :result_for
+  end
+
+  class InitAddTests < InitTests
+    desc "#add"
+
+    let(:exception_class){ StandardError }
+    let(:block){ proc{ MuchResult.failure } }
+
+    let(:invalid_exception_class) do
+      [
+        Class.new,
+        Factory.string,
+        nil,
+      ].sample
+    end
+
+    should "add an exception class and block" do
+      subject.add(exception_class, &block)
+      assert_that(subject.hash[exception_class]).is(block)
+    end
+
+    should "raise an error when it's not passed an Exception" do
+      assert_that{
+        subject.add(invalid_exception_class, &block)
+      }.raises(ArgumentError)
+    end
+  end
+
+  class InitExceptionClassesTests < InitTests
+    desc "#exception_classes"
+
+    setup do
+      exception_classes.each do |exception_class|
+        subject.add(exception_class, &block)
+      end
+    end
+
+    let(:exception_classes) do
+      [
+        StandardError,
+        ArgumentError,
+        RuntimeError,
+      ]
+    end
+    let(:block){ proc{ MuchResult.failure } }
+
+    should "return all the added exception classes" do
+      assert_that(subject.exception_classes).equals(exception_classes)
+    end
+  end
+
+  class InitResultForTests < InitTests
+    desc "#result_for"
+
+    setup do
+      subject.add(exception_class, &block)
+    end
+
+    let(:exception){ exception_class.new(Factory.string) }
+    let(:exception_class){ StandardError }
+    let(:block) do
+      proc{ MuchResult.failure(error_message: failure_result_error_message) }
+    end
+    let(:failure_result_error_message){ Factory.string }
+
+    let(:inherited_exception){ RuntimeError.new(Factory.string) }
+
+    let(:invalid_exception){ Exception.new(Factory.string) }
+
+    should "return the result of calling the added block "\
+           "for the exception class" do
+      result = subject.result_for(exception)
+      assert_that(result.failure?).is_true
+      assert_that(result.error_message).equals(failure_result_error_message)
+    end
+
+    should "return the result of calling the added block "\
+           "for an exception class ancestor" do
+      result = subject.result_for(exception)
+      assert_that(result.failure?).is_true
+      assert_that(result.error_message).equals(failure_result_error_message)
+    end
+
+    should "raise an error if a block hasn't been added "\
+           "for the exception class" do
+      assert_that{
+        subject.result_for(invalid_exception)
+      }.raises(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This updates the `SaveService` and `DestroyService` mixins to
allow configuring which exceptions they rescue and how they
handle them. The goal of this is to allow configuring custom
exceptions and have them return failure (or success if you want)
results in an expected format. The original goal was to just
configure exception classes and use the same logic to build a
similar failure result but I realized that since we don't control
exceptions like `ActiveRecord::RecordInvalid` this doesn't scale
well. Thus, this allows configuring an exception class with a
block that builds the result the `SaveService` or `DestroyService`
should return.

By default, `SaveService` is configured to work with
`ActiveRecord::RecordInvalid` and `DestroyService` is configured
to work with `MuchRails::Records::DestructionInvalid`. This
matches how they previously worked before this commit.

# Other Changes

#### Rename `DestructionInvalid` error

This renames the `DestructionInvalid` that the
`ValidateDestroy` mixin uses. This removes it from the
`ValidateDestroy` namespace so it's now named
`MuchRails::Records::DestructionInvalid`. This more closely
matches `ActiveRecord::RecordInvalid`.

#### Make `DestroyService` failure result similar to `SaveService` failure result

This updates the failure result that the `DestroyService` builds
to be similar to the failure result that the `SaveService` builds.
This is just to make them similar so we have the same options
when handling either failure result.

This also updates the `MuchRails::Records::DestructionInvalid`
exception to support the `DestroyService`. This adds error
full messages to the exception and renames the
`destruction_errors` to `errors`.