### PR TITLE
rework Assets hosting to not implicity ERB vendor assets

### DIFF
--- a/lib/much-rails/assets.rb
+++ b/lib/much-rails/assets.rb
@@ -33,20 +33,39 @@ module MuchRails::Assets
         config.file_store rails.root.join("public")
       end
 
-      # Look for asset files in the app/assets folder. Support ERB processing
-      # on all .js and .scss files. Support compilation of .scss files.
-      config.source rails.root.join("app", "assets") do |s|
+      # Look for asset files in the app/assets/css folder. Support ERB
+      # on all .scss files. Support compilation of .scss files.
+      config.source rails.root.join("app", "assets", "css") do |s|
+        s.base_path "css"
+
         # Reject SCSS partials
         s.filter do |paths|
           paths.reject{ |p| File.basename(p) =~ /^_.*\.scss$/ }
         end
 
-        s.engine "js",   MuchRails::Assets::Erubi::Engine
         s.engine "scss", MuchRails::Assets::Erubi::Engine
         s.engine "scss", MuchRails::Assets::Sass::Engine, {
           syntax: "scss",
           output_style: "compressed",
         }
+      end
+
+      # Look for asset files in the app/assets/img folder.
+      config.source rails.root.join("app", "assets", "img") do |s|
+        s.base_path "img"
+      end
+
+      # Look for asset files in the app/assets/js folder. Support ERB
+      # on all .js files.
+      config.source rails.root.join("app", "assets", "js") do |s|
+        s.base_path "js"
+
+        s.engine "js", MuchRails::Assets::Erubi::Engine
+      end
+
+      # Look for asset files in the app/assets/vendor folder
+      config.source rails.root.join("app", "assets", "vendor") do |s|
+        s.base_path "vendor"
       end
     end
     MuchRails::Assets.init

--- a/lib/much-rails/assets.rb
+++ b/lib/much-rails/assets.rb
@@ -12,20 +12,16 @@ end
 module MuchRails::Assets
   def self.configure_for_rails(rails)
     MuchRails::Assets.configure do |config|
-      # Cache fingerprints in memory for performance gains.
-      config.fingerprint_cache MuchRails::Assets::MemCache.new
-
-      # Cache compiled content in memory in development/test for performance
-      # gains since we aren't caching to the file system. Otherwise, don't
-      # cache in memory as we are caching to the file system and won't benefit
-      # from the in memory cache.
-      much_rails_content_cache =
-        if rails.env.development? || rails.env.test?
-          MuchRails::Assets::MemCache.new
-        else
-          MuchRails::Assets::NoCache.new
-        end
-      config.content_cache much_rails_content_cache
+      # Cache fingerprints/content in memory in non-development for performance
+      # gains. Don't cache in memory in developlemnt so changes are reflected
+      # without restarting the server.
+      if !rails.env.development?
+        config.fingerprint_cache MuchRails::Assets::MemCache.new
+        config.content_cache MuchRails::Assets::MemCache.new
+      else
+        config.fingerprint_cache MuchRails::Assets::NoCache.new
+        config.content_cache MuchRails::Assets::NoCache.new
+      end
 
       # Cache out compiled file content to the public folder in non
       # development/test environments.

--- a/lib/much-rails/service_validation_errors.rb
+++ b/lib/much-rails/service_validation_errors.rb
@@ -10,7 +10,7 @@ class MuchRails::ServiceValidationErrors
   end
 
   def add(exception_class, &block)
-    unless exception_class < Exception
+    unless exception_class && exception_class < Exception
       raise(ArgumentError, "#{exception_class} is not an Exception")
     end
 

--- a/much-rails.gemspec
+++ b/much-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("activerecord",   ["> 5.0", "< 7.0"])
   gem.add_dependency("activesupport",  ["> 5.0", "< 7.0"])
-  gem.add_dependency("dassets",        ["~> 0.15.1"])
+  gem.add_dependency("dassets",        ["~> 0.15.2"])
   gem.add_dependency("dassets-erubi",  ["~> 0.1.1"])
   gem.add_dependency("dassets-sass",   ["~> 0.5.1"])
   gem.add_dependency("much-boolean",   ["~> 0.2.1"])

--- a/test/unit/assets_tests.rb
+++ b/test/unit/assets_tests.rb
@@ -49,21 +49,54 @@ module MuchRails::Assets
         .is_not_equal_to(FakeRails.root.join("public"))
     end
 
-    should "configure the app's app/assets folder as a source" do
+    should "configure the app's app/assets/css folder as a source" do
       source =
         subject.config.sources.detect do |source|
-          source.path == FakeRails.root.join("app", "assets").to_s
+          source.path == FakeRails.root.join("app", "assets", "css").to_s
         end
 
       assert_that(source).is_not_nil
-      assert_that(source.engines["js"].size).equals(1)
-      assert_that(source.engines["js"].first)
-        .is_instance_of(subject::Erubi::Engine)
+      assert_that(source.base_path).equals("css")
       assert_that(source.engines["scss"].size).equals(2)
       assert_that(source.engines["scss"].first)
         .is_instance_of(subject::Erubi::Engine)
       assert_that(source.engines["scss"].last)
         .is_instance_of(subject::Sass::Engine)
+    end
+
+    should "configure the app's app/assets/img folder as a source" do
+      source =
+        subject.config.sources.detect do |source|
+          source.path == FakeRails.root.join("app", "assets", "img").to_s
+        end
+
+      assert_that(source).is_not_nil
+      assert_that(source.base_path).equals("img")
+      assert_that(source.engines.empty?).is_true
+    end
+
+    should "configure the app's app/assets/js folder as a source" do
+      source =
+        subject.config.sources.detect do |source|
+          source.path == FakeRails.root.join("app", "assets", "js").to_s
+        end
+
+      assert_that(source).is_not_nil
+      assert_that(source.base_path).equals("js")
+      assert_that(source.engines["js"].size).equals(1)
+      assert_that(source.engines["js"].first)
+        .is_instance_of(subject::Erubi::Engine)
+    end
+
+    should "configure the app's app/assets/vendor folder as a source" do
+      source =
+        subject.config.sources.detect do |source|
+          source.path == FakeRails.root.join("app", "assets", "vendor").to_s
+        end
+
+      assert_that(source).is_not_nil
+      assert_that(source.base_path).equals("vendor")
+      assert_that(source.engines.empty?).is_true
     end
 
     should "initialize itself" do

--- a/test/unit/assets_tests.rb
+++ b/test/unit/assets_tests.rb
@@ -23,7 +23,7 @@ module MuchRails::Assets
     setup do
       subject.reset
 
-      in_development_env = Factory.boolean
+      in_development_env = true
       Assert.stub(FakeRails.env, :development?){ in_development_env }
       Assert.stub(FakeRails.env, :test?){ !in_development_env }
 
@@ -34,14 +34,11 @@ module MuchRails::Assets
       subject.configure_for_rails(FakeRails)
     end
 
-    should "configure the fingerprint cache to use a memory cache" do
+    should "configure the fingerprint/content cache to use no cache" do
       assert_that(subject.config.fingerprint_cache)
-        .is_instance_of(subject::MemCache)
-    end
-
-    should "configure the content cache to use a memory cache" do
+        .is_instance_of(subject::NoCache)
       assert_that(subject.config.content_cache)
-        .is_instance_of(subject::MemCache)
+        .is_instance_of(subject::NoCache)
     end
 
     should "not configure a file store" do
@@ -117,9 +114,11 @@ module MuchRails::Assets
       subject.configure_for_rails(FakeRails)
     end
 
-    should "configure the content cache to use no cache" do
+    should "configure the fingerprint/content cache to use a memory cache" do
+      assert_that(subject.config.fingerprint_cache)
+        .is_instance_of(subject::MemCache)
       assert_that(subject.config.content_cache)
-        .is_instance_of(subject::NoCache)
+        .is_instance_of(subject::MemCache)
     end
 
     should "configure a file store for the app's public folder" do


### PR DESCRIPTION
You can't guarantee other people's code can be safely ERB'd. I
noticed this while vendoring in a 3rd-party JS file.

This also fixes a randomly failing test that came up when testing.# Other Changes

### update Assets caching to not use cache in development

This ensures changes are reflected without restarting the server
as is the convention in Rails apps.
