### PR TITLE
add MuchRails::AbstractClass

### DIFF
--- a/lib/much-rails.rb
+++ b/lib/much-rails.rb
@@ -4,6 +4,7 @@ require "active_support"
 require "active_support/core_ext"
 
 require "much-rails/version"
+require "much-rails/abstract_class"
 require "much-rails/action"
 require "much-rails/boolean"
 require "much-rails/call_method"

--- a/lib/much-rails/abstract_class.rb
+++ b/lib/much-rails/abstract_class.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "much-rails/mixin"
+
+# MuchRails::AbstractClass overrides the `new` class method to prevent a class
+# from being instantiated directly.
+module MuchRails::AbstractClass
+  include MuchRails::Mixin
+
+  after_mixin_included do
+    self.abstract_class = self
+
+    define_singleton_method(:new) do |*args, &block|
+      if abstract_class?
+        raise(
+          NotImplementedError,
+          "#{self} is an abstract class and cannot be instantiated.",
+        )
+      end
+
+      super(*args, &block)
+    end
+  end
+
+  mixin_class_methods do
+    def abstract_class
+      @abstract_class
+    end
+
+    def abstract_class=(value)
+      @abstract_class = value
+    end
+
+    def abstract_class?
+      !!(abstract_class == self)
+    end
+  end
+end

--- a/test/unit/abstract_class_tests.rb
+++ b/test/unit/abstract_class_tests.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "assert"
+require "much-rails/abstract_class"
+
+module MuchRails::AbstractClassTest
+  class UnitTests < Assert::Context
+    desc "MuchRails::AbstractClass"
+    subject{ unit_class }
+
+    let(:unit_class){ MuchRails::AbstractClass }
+
+    should "include MuchRails::Mixin" do
+      assert_that(subject).includes(MuchRails::Mixin)
+    end
+  end
+
+  class ReceiverTests < UnitTests
+    desc "receiver"
+    subject{ receiver_class }
+
+    let(:receiver_class) do
+      Class.new.tap{ |c| c.include unit_class }
+    end
+    let(:receiver_subclass) do
+      Class.new(receiver_class)
+    end
+
+    should have_accessor :abstract_class
+    should have_imeths :new, :abstract_class?
+
+    should "know if it is an abstract class or not" do
+      assert_that(subject.abstract_class?).equals(true)
+      assert_that(receiver_subclass.abstract_class?).equals(false)
+    end
+
+    should "prevent calling .new on the receiver" do
+      assert_that{ subject.new }.raises(NotImplementedError)
+    end
+
+    should "allow calling .new on subclasses of the receiver" do
+      assert_that(receiver_subclass.new).is_a?(subject)
+    end
+  end
+end


### PR DESCRIPTION
This is used to formally define abstract classes that can't be
initialized directly.
