### PR TITLE
pass kargs, symbolize the keys on any arguments passed to Router route generation methods

### DIFF
--- a/lib/much-rails/action/base_router.rb
+++ b/lib/much-rails/action/base_router.rb
@@ -70,8 +70,8 @@ class MuchRails::Action::BaseRouter
   #       url :users, "/users", "Users::Index"
   #     }
   #   AdminRouter.path_for(:users) # => "/admin/users"
-  def path_for(name, *args)
-    @url_set.path_for(name, *args)
+  def path_for(name, **kargs)
+    @url_set.path_for(name, **kargs)
   end
 
   # Example:
@@ -87,8 +87,8 @@ class MuchRails::Action::BaseRouter
   #       url :users, "/users", "Users::Index"
   #     }
   #   AdminRouter.url_for(:users) # => "http://example.org/admin/users"
-  def url_for(name, *args)
-    @url_set.url_for(name, *args)
+  def url_for(name, **kargs)
+    @url_set.url_for(name, **kargs)
   end
 
   # Example:
@@ -350,12 +350,12 @@ class MuchRails::Action::BaseRouter
       end
     end
 
-    def path_for(name, *args)
-      fetch(name).path_for(*args)
+    def path_for(name, **kargs)
+      fetch(name).path_for(**kargs)
     end
 
-    def url_for(name, *args)
-      fetch(name).url_for(*args)
+    def url_for(name, **kargs)
+      fetch(name).url_for(**kargs)
     end
   end
 
@@ -396,11 +396,11 @@ class MuchRails::Action::BaseRouter
       self.class.url_path(@router, @url_path)
     end
 
-    def path_for(*args)
+    def path_for(**kargs)
       raise NotImplementedError
     end
 
-    def url_for(*args)
+    def url_for(**kargs)
       raise NotImplementedError
     end
 

--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -90,12 +90,18 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
   alias_method :draw, :apply_to
 
   class URL < MuchRails::Action::BaseRouter::BaseURL
-    def path_for(*args)
-      MuchRails::RailsRoutes.instance.public_send("#{name}_path", *args)
+    def path_for(**kargs)
+      MuchRails::RailsRoutes.instance.public_send(
+        "#{name}_path",
+        **kargs.symbolize_keys,
+      )
     end
 
-    def url_for(*args)
-      MuchRails::RailsRoutes.instance.public_send("#{name}_url", *args)
+    def url_for(**kargs)
+      MuchRails::RailsRoutes.instance.public_send(
+        "#{name}_url",
+        **kargs.symbolize_keys,
+      )
     end
   end
 end

--- a/test/unit/action/base_router_tests.rb
+++ b/test/unit/action/base_router_tests.rb
@@ -80,13 +80,13 @@ class MuchRails::Action::BaseRouter
     end
 
     should "build path/URL strings for named URLs" do
-      path_string = subject.path_for(:url1, "TEST PATH ARGS")
+      path_string = subject.path_for(:url1, test: "args")
       assert_that(path_string).equals("TEST PATH STRING")
-      assert_that(@url_set_path_for_call.args).equals([:url1, "TEST PATH ARGS"])
+      assert_that(@url_set_path_for_call.args).equals([:url1, { test: "args" }])
 
-      url_string = subject.url_for(:url1, "TEST URL ARGS")
+      url_string = subject.url_for(:url1, test: "args")
       assert_that(url_string).equals("TEST URL STRING")
-      assert_that(@url_set_url_for_call.args).equals([:url1, "TEST URL ARGS"])
+      assert_that(@url_set_url_for_call.args).equals([:url1, { test: "args" }])
     end
 
     should "define request types" do
@@ -380,13 +380,13 @@ class MuchRails::Action::BaseRouter
 
       subject.add(:url1, Factory.url)
 
-      path_string = subject.path_for(:url1, "TEST PATH ARGS")
+      path_string = subject.path_for(:url1, test: "args")
       assert_that(path_string).equals("TEST PATH STRING")
-      assert_that(@url_path_for_call.args).equals(["TEST PATH ARGS"])
+      assert_that(@url_path_for_call.args).equals([{ test: "args" }])
 
-      url_string = subject.url_for(:url1, "TEST URL ARGS")
+      url_string = subject.url_for(:url1, test: "args")
       assert_that(url_string).equals("TEST URL STRING")
-      assert_that(@url_url_for_call.args).equals(["TEST URL ARGS"])
+      assert_that(@url_url_for_call.args).equals([{ test: "args" }])
     end
   end
 
@@ -450,8 +450,8 @@ class MuchRails::Action::BaseRouter
       assert_that(subject.path)
         .equals(base_url_class.url_path(router1, url_path1))
 
-      assert_that{ subject.path_for("TEST ARGS") }.raises(NotImplementedError)
-      assert_that{ subject.url_for("TEST ARGS") }.raises(NotImplementedError)
+      assert_that{ subject.path_for(test: "args") }.raises(NotImplementedError)
+      assert_that{ subject.url_for(test: "args") }.raises(NotImplementedError)
     end
   end
 

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -206,15 +206,15 @@ class MuchRails::Action::Router
     should have_imeths :path_for, :url_for
 
     should "know its attributes" do
-      path_string = subject.path_for("TEST PATH ARGS")
+      path_string = subject.path_for(test: "args")
       assert_that(path_string).equals("TEST PATH OR URL STRING")
       assert_that(@rails_routes_method_missing_call.args)
-        .equals(["#{url_name1}_path".to_sym, "TEST PATH ARGS"])
+        .equals(["#{url_name1}_path".to_sym, { test: "args" }])
 
-      url_string = subject.url_for("TEST URL ARGS")
+      url_string = subject.url_for(test: "args")
       assert_that(url_string).equals("TEST PATH OR URL STRING")
       assert_that(@rails_routes_method_missing_call.args)
-        .equals(["#{url_name1}_url".to_sym, "TEST URL ARGS"])
+        .equals(["#{url_name1}_url".to_sym, { test: "args" }])
     end
   end
 


### PR DESCRIPTION

Rails requires symbol keys for generating routs. This also switches
to using splatted kargs since passing hashes won't work with
kargs in Ruby 3.0.

I noticed this while generating non-trivial routes in an app.
