### PR TITLE
add presence check to MuchRails::InputValue.strip

### DIFF
--- a/lib/much-rails/input_value.rb
+++ b/lib/much-rails/input_value.rb
@@ -7,7 +7,7 @@ module MuchRails::InputValue
   def self.strip(value)
     return if value.blank?
 
-    value.to_s.strip
+    value.to_s.strip.presence
   end
 
   def self.strip_all(values)

--- a/test/unit/input_value_tests.rb
+++ b/test/unit/input_value_tests.rb
@@ -9,12 +9,21 @@ module MuchRails::InputValue
     subject{ unit_class }
 
     let(:unit_class){ MuchRails::InputValue }
+    let(:non_blank_but_empty_to_s_object) do
+      Class
+        .new{
+          def to_s
+            ["", " "].sample
+          end
+        }
+        .new
+    end
 
     should have_imeths :strip, :strip_all
 
     should "know its attributes" do
       # strip
-      input_value = [nil, "", " "].sample
+      input_value = [nil, "", " ", non_blank_but_empty_to_s_object].sample
       assert_that(subject.strip(input_value)).is_nil
 
       input_value = [" VALUE  ", "\r VALUE\n"].sample


### PR DESCRIPTION
This ensures all values who aren't blank themselves but for some
reason their `to_s` is blank are normalized to `nil`.

@jcredding I know this is a little contrived of a case to cover but I figure why not? Any concerns?