### PR TITLE
update to build actions with current_session

### DIFF
--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -31,7 +31,7 @@ module MuchRails::Action
 
     add_config :much_rails_action
 
-    attr_reader :params, :current_user, :request, :errors
+    attr_reader :params, :current_session, :request, :errors
   end
 
   mixin_class_methods do
@@ -115,9 +115,9 @@ module MuchRails::Action
   end
 
   mixin_instance_methods do
-    def initialize(params: nil, current_user: nil, request: nil)
+    def initialize(params: nil, current_session: nil, request: nil)
       @params = params.to_h.with_indifferent_access
-      @current_user = current_user
+      @current_session = current_session
       @request = request
       @errors = Hash.new{ |hash, key| hash[key] = [] }
     end

--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -32,7 +32,7 @@ module MuchRails::Action::Controller
           result =
             much_rails_action_class.call(
               params: much_rails_action_params,
-              current_user: current_user,
+              current_session: current_session,
               request: request,
             )
           instance_exec(result, &result.execute_block)

--- a/test/unit/action_tests.rb
+++ b/test/unit/action_tests.rb
@@ -178,7 +178,7 @@ module MuchRails::Action
     subject do
       receiver_class.new(
         params: params1,
-        current_user: current_user1,
+        current_session: current_session1,
         request: request1,
       )
     end
@@ -234,15 +234,15 @@ module MuchRails::Action
         active: "true",
       }
     end
-    let(:current_user1){ "CURRENT USER 1" }
+    let(:current_session1){ "CURRENT SESSION 1" }
     let(:request1){ "REQUEST 1" }
 
-    should have_readers :params, :current_user, :request, :errors
+    should have_readers :params, :current_session, :request, :errors
     should have_imeths :on_call, :valid_action?, :successful_action?
 
     should "know its attributes" do
       assert_that(subject.params).equals(params1.with_indifferent_access)
-      assert_that(subject.current_user).equals(current_user1)
+      assert_that(subject.current_session).equals(current_session1)
       assert_that(subject.request).equals(request1)
     end
 

--- a/test/unit/change_action_tests.rb
+++ b/test/unit/change_action_tests.rb
@@ -61,7 +61,7 @@ module MuchRails::ChangeAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end
@@ -87,7 +87,7 @@ module MuchRails::ChangeAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end
@@ -121,7 +121,7 @@ module MuchRails::ChangeAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end
@@ -152,7 +152,7 @@ module MuchRails::ChangeAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end
@@ -181,7 +181,7 @@ module MuchRails::ChangeAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end
@@ -208,7 +208,7 @@ module MuchRails::ChangeAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end
@@ -235,7 +235,7 @@ module MuchRails::ChangeAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end

--- a/test/unit/destroy_action_tests.rb
+++ b/test/unit/destroy_action_tests.rb
@@ -53,7 +53,7 @@ module MuchRails::DestroyAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end

--- a/test/unit/save_action_tests.rb
+++ b/test/unit/save_action_tests.rb
@@ -53,7 +53,7 @@ module MuchRails::SaveAction
     subject do
       receiver_class.new(
         params: {},
-        current_user: nil,
+        current_session: nil,
         request: nil,
       )
     end


### PR DESCRIPTION
This updates `MuchRails::Action` to instead use and auto-build
actions with a `current_session` rather than `current_user`.
This provides a more generic object, with both session and current
user data.

