### PR TITLE
call `underscore` when setting action template name

### DIFF
--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -107,10 +107,7 @@ module MuchRails::Action
 
     def default_action_template_name
       @default_action_template_name ||=
-        to_s
-          .remove(/\A#{MuchRails.config.action.namespace}/)
-          .tableize
-          .singularize
+        to_s.remove(/\A#{MuchRails.config.action.namespace}/).underscore
     end
   end
 

--- a/test/unit/action_tests.rb
+++ b/test/unit/action_tests.rb
@@ -167,7 +167,7 @@ module MuchRails::Action
       assert_that(subject.default_action_template_name)
         .equals(
           "some/namespace/for/"\
-          "#{MuchRails.config.action.namespace.tableize.singularize}"\
+          "#{MuchRails.config.action.namespace.underscore}"\
           "thing/show",
         )
     end


### PR DESCRIPTION
This updates the `default_action_template_name` method in
`Action` to no longer call `tableize` and `singularize`, but
instead just call `underscore`. This was causing an issue with
`New` actions as `singularize` does not turn "news" into "new" as
expected.
