### PR TITLE
update Action `render` method to set itself on any supported view models

### DIFF
--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -254,6 +254,10 @@ module MuchRails::Action
           template: template || default_action_template_name,
         }.merge(**kargs)
 
+      if view_model&.respond_to?(:much_rails_action=)
+        view_model.much_rails_action = self
+      end
+
       @much_rails_action_result =
         MuchRails::Action::RenderResult.new(view_model, *args, **result_kargs)
       halt

--- a/test/unit/action_tests.rb
+++ b/test/unit/action_tests.rb
@@ -318,6 +318,7 @@ module MuchRails::Action
           layout: false,
         )
 
+      view_model = Object.new
       receiver_class.on_call do
         render(view_model, "some/view/template", layout: false)
       end
@@ -330,18 +331,29 @@ module MuchRails::Action
           layout: false,
         )
 
+      view_model =
+        Class
+          .new{
+            def much_rails_action
+              "NOT A MUCH RAILS ACTION"
+            end
+          }
+          .new
       receiver_class.on_call do
         render(view_model, "some/view/template", template: "other/template")
       end
       action = receiver_class.new(params: params1)
       result = action.call
       assert_that(result.render_view_model).is(view_model)
+      assert_that(result.render_view_model.much_rails_action).is_not(action)
       assert_that(result.render_kargs).equals(template: "other/template")
 
+      view_model = Struct.new(:much_rails_action).new(nil)
       receiver_class.on_call{ render(view_model, template: "other/template") }
       action = receiver_class.new(params: params1)
       result = action.call
       assert_that(result.render_view_model).is(view_model)
+      assert_that(result.render_view_model.much_rails_action).is(action)
       assert_that(result.render_kargs).equals(template: "other/template")
     end
 


### PR DESCRIPTION
This introduces an ah-hoc method for letting view models tell the
Action instances that they are interested in collaborating with
the Action. If the view model instances respond to
`#much_rails_action=` then the Action messages the view model
passing itself. The view model can then use the Action instance
however it sees fit.

Note, view models could opt to, instead, just take the action
instance or one it its properties as an argument to its
constructor. This works if the view model directly knows it wants
the Action instance. However, in some cases the View Model may
use e.g. a layout mixin that want's to message the Action. In this
case the view model doesn't know/care that something it mixes in
wants/needs the Action instancd. Why should the view model junk
up its constructor in non-obvious ways. This approach allows the
mixin that needs the Action to also define the `much_rails_action=`
method to give itself access to the Action and the main view model
is happily none-the-wiser.
