### PR TITLE
fix a bug applying multiple routes with the same definition name

### DIFF
--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -52,13 +52,15 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
     draw_url_to   = "#{controller_name}##{CONTROLLER_NOT_FOUND_METHOD_NAME}"
     draw_route_to = "#{controller_name}##{CONTROLLER_CALL_ACTION_METHOD_NAME}"
 
+    definition_names = Set.new
+
     definitions.each do |definition|
       definition.request_type_actions.each do |request_type_action|
         application_routes_draw_scope.public_send(
           definition.http_method,
           definition.path,
           to: draw_route_to,
-          as: definition.name,
+          as: (definition.name if definition_names.add?(definition.name)),
           defaults:
             definition.default_params.merge({
               ACTION_CLASS_PARAM_NAME => request_type_action.class_name,
@@ -73,7 +75,7 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
         definition.http_method,
         definition.path,
         to: draw_route_to,
-        as: definition.name,
+        as: (definition.name if definition_names.add?(definition.name)),
         defaults:
           definition.default_params.merge({
             ACTION_CLASS_PARAM_NAME => definition.default_action_class_name,

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -120,7 +120,7 @@ class MuchRails::Action::Router
       assert_that(application_routes.get_calls[1].kargs)
         .equals(
           to: expected_draw_route_to,
-          as: url_name,
+          as: nil,
           defaults: expected_default_defaults,
         )
       assert_that(application_routes.get_calls[2].pargs).equals([url2_path])
@@ -135,7 +135,7 @@ class MuchRails::Action::Router
       assert_that(application_routes.post_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,
-          as: url_name,
+          as: nil,
           defaults: expected_default_defaults,
         )
 
@@ -153,7 +153,7 @@ class MuchRails::Action::Router
       assert_that(application_routes.patch_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,
-          as: url_name,
+          as: nil,
           defaults: expected_default_defaults,
         )
 
@@ -162,7 +162,7 @@ class MuchRails::Action::Router
       assert_that(application_routes.delete_calls.last.kargs)
         .equals(
           to: expected_draw_route_to,
-          as: url_name,
+          as: nil,
           defaults: expected_default_defaults,
         )
     end


### PR DESCRIPTION
Previously, declaring two Actions that both handle the same URL 
with e.g. different HTTP methods ...

```ruby
url :person_show, "/persion/:id"

get  :person_show, "Views::People::Show"
post :person_show, "Views::People::Show"
```
... would raise:

```
Invalid route name, already in use: 'person_show'  (ArgumentError)
```

With this fix, we track the unique route names that have been used
and hold Rails's hand and don't tell it to use a route name that
has already been used. This fixes the bug.
