### PR TITLE
set Action format as a default in Action::Router routes

### DIFF
--- a/lib/much-rails/action/base_router.rb
+++ b/lib/much-rails/action/base_router.rb
@@ -149,7 +149,7 @@ class MuchRails::Action::BaseRouter
   #       get    "/new",    "Root::New"
   #       post   "/",       "Root::Create"
   #       get    "/edit",   "Root::Edit"
-  #       put    "/",       "Root::Update"
+  #       put    "/",       "Root::Upsert"
   #       patch  "/",       "Root::Update"
   #       get    "/remove", "Root::Remove"
   #       delete "/",       "Root::Destroy"
@@ -300,6 +300,14 @@ class MuchRails::Action::BaseRouter
     Struct.new(:request_type, :class_name) do
       def constraints_lambda
         request_type.constraints_lambda
+      end
+
+      def class_constant
+        @class_constant ||= class_name.constantize
+      end
+
+      def format
+        class_constant.format
       end
     end
 
@@ -458,6 +466,16 @@ class MuchRails::Action::BaseRouter
 
     def has_default_action_class_name?
       !@default_action_class_name.nil?
+    end
+
+    def default_action_class_constant
+      return unless has_default_action_class_name?
+
+      @default_action_class_constant ||= default_action_class_name.constantize
+    end
+
+    def default_action_format
+      default_action_class_constant&.format
     end
 
     def ==(other)

--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -64,6 +64,7 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
           defaults:
             definition.default_params.merge({
               ACTION_CLASS_PARAM_NAME => request_type_action.class_name,
+              "format" => request_type_action.format,
             }),
           constraints: request_type_action.constraints_lambda,
         )
@@ -79,6 +80,7 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
         defaults:
           definition.default_params.merge({
             ACTION_CLASS_PARAM_NAME => definition.default_action_class_name,
+            "format" => definition.default_action_format,
           }),
       )
     end

--- a/test/support/actions/show.rb
+++ b/test/support/actions/show.rb
@@ -7,5 +7,7 @@ module Actions; end
 module Actions::Show
   include MuchRails::Action
 
+  format :html
+
   params_root :nested
 end

--- a/test/unit/action/base_router_tests.rb
+++ b/test/unit/action/base_router_tests.rb
@@ -296,20 +296,30 @@ class MuchRails::Action::BaseRouter
     desc "when init"
     subject{ request_type_action_class.new(request_type1, action_class_name1) }
 
+    setup do
+      Assert.stub(action_class_name1, :constantize){ action_class1 }
+    end
+
     let(:name1){ Factory.symbol }
     let(:constraints_lambda1){ ->(request){} }
     let(:request_type1) do
       unit_class::RequestType.new(name1, constraints_lambda1)
     end
     let(:action_class_name1){ Factory.string }
+    let(:action_class1) do
+      Struct.new(:format).new([:html, :any].sample)
+    end
 
     should have_imeths :request_type, :class_name, :constraints_lambda
+    should have_imeths :class_constant, :format
 
     should "know its attributes" do
       assert_that(subject.request_type).equals(request_type1)
       assert_that(subject.class_name).equals(action_class_name1)
       assert_that(subject.constraints_lambda)
         .equals(request_type1.constraints_lambda)
+      assert_that(subject.class_constant).equals(action_class1)
+      assert_that(subject.format).equals(subject.class_constant.format)
     end
   end
 
@@ -506,6 +516,15 @@ class MuchRails::Action::BaseRouter
       )
     end
 
+    setup do
+      Assert.stub(default_action_class_name1, :constantize) do
+        default_action_class1
+      end
+    end
+
+    let(:default_action_class1) do
+      Struct.new(:format).new([:html, :any].sample)
+    end
     let(:default_params1) do
       { Factory.string => Factory.string }
     end
@@ -514,6 +533,7 @@ class MuchRails::Action::BaseRouter
     should have_readers :default_action_class_name, :request_type_actions
     should have_readers :called_from
     should have_imeths :path, :name, :has_default_action_class_name?
+    should have_imeths :default_action_class_constant, :default_action_format
 
     should "know its attributes" do
       assert_that(subject.http_method).equals(http_method1)
@@ -525,6 +545,10 @@ class MuchRails::Action::BaseRouter
       assert_that(subject.called_from).equals(caller1)
       assert_that(subject.path).equals(url_path1)
       assert_that(subject.name).equals(url_name1)
+      assert_that(subject.default_action_class_constant)
+        .equals(default_action_class1)
+      assert_that(subject.default_action_format)
+        .equals(subject.default_action_class_constant.format)
     end
   end
 end

--- a/test/unit/action/controller_tests.rb
+++ b/test/unit/action/controller_tests.rb
@@ -35,6 +35,10 @@ module MuchRails::Action::Controller
     desc "when init"
     subject{ receiver_class.new(params1) }
 
+    setup do
+      Assert.stub(::Actions::Show, :format){ nil }
+    end
+
     let(:params1) do
       {
         MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME => "Actions::Show",
@@ -75,10 +79,9 @@ module MuchRails::Action::Controller
 
       assert_that(subject.much_rails_action_class).equals(Actions::Show)
 
-      Actions::Show.format(:html)
+      Assert.stub(::Actions::Show, :format){ :html }
       receiver = receiver_class.new(params1)
       assert_that(receiver.much_rails_action_class_format).equals(:html)
-      Actions::Show.format(nil)
     end
   end
 

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -104,7 +104,10 @@ class MuchRails::Action::Router
         "#{subject.controller_name}"\
         "##{unit_class::CONTROLLER_CALL_ACTION_METHOD_NAME}"
       expected_default_defaults =
-        { unit_class::ACTION_CLASS_PARAM_NAME => default_class_name }
+        {
+          unit_class::ACTION_CLASS_PARAM_NAME => default_class_name,
+          "format" => :html,
+        }
 
       assert_that(application_routes.get_calls.size).equals(3)
       assert_that(application_routes.get_calls[0].pargs).equals([url_path])
@@ -113,7 +116,10 @@ class MuchRails::Action::Router
           to: expected_draw_route_to,
           as: url_name,
           defaults:
-            { unit_class::ACTION_CLASS_PARAM_NAME => request_type_class_name },
+            {
+              unit_class::ACTION_CLASS_PARAM_NAME => request_type_class_name,
+              "format" => :html,
+            },
           constraints: request_type_proc,
         )
       assert_that(application_routes.get_calls[1].pargs).equals([url_path])


### PR DESCRIPTION
This ensures the format specified by the Action is the default one
used by Rails when handling the Action in the Action::Controller.
