### PR TITLE
ignore format kargs when generating URLs/paths

### DIFF
--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -97,14 +97,14 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
     def path_for(**kargs)
       MuchRails::RailsRoutes.instance.public_send(
         "#{name}_path",
-        **kargs.symbolize_keys,
+        **kargs.symbolize_keys.except(:format),
       )
     end
 
     def url_for(**kargs)
       MuchRails::RailsRoutes.instance.public_send(
         "#{name}_url",
-        **kargs.symbolize_keys,
+        **kargs.symbolize_keys.except(:format),
       )
     end
   end

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -212,12 +212,12 @@ class MuchRails::Action::Router
     should have_imeths :path_for, :url_for
 
     should "know its attributes" do
-      path_string = subject.path_for(test: "args")
+      path_string = subject.path_for(test: "args", format: "html")
       assert_that(path_string).equals("TEST PATH OR URL STRING")
       assert_that(@rails_routes_method_missing_call.args)
         .equals(["#{url_name1}_path".to_sym, { test: "args" }])
 
-      url_string = subject.url_for(test: "args")
+      url_string = subject.url_for(test: "args", format: "xml")
       assert_that(url_string).equals("TEST PATH OR URL STRING")
       assert_that(@rails_routes_method_missing_call.args)
         .equals(["#{url_name1}_url".to_sym, { test: "args" }])


### PR DESCRIPTION
MuchRails routing/actions are one-format-per-route-and-action.
Therefore there is no point in passing in dynamic formats and
generating routes with dynamic formats. This preemptively removes
any given format to avoid unexpected behaviors.
