### PR TITLE
add API for interacting with the Rails controller session on Actions

### DIFF
--- a/lib/much-rails/action.rb
+++ b/lib/much-rails/action.rb
@@ -31,7 +31,7 @@ module MuchRails::Action
 
     add_config :much_rails_action
 
-    attr_reader :params, :current_session, :request, :errors
+    attr_reader :params, :request, :errors
   end
 
   mixin_class_methods do
@@ -112,9 +112,8 @@ module MuchRails::Action
   end
 
   mixin_instance_methods do
-    def initialize(params: nil, current_session: nil, request: nil)
+    def initialize(params: nil, request: nil)
       @params = params.to_h.with_indifferent_access
-      @current_session = current_session
       @request = request
       @errors = Hash.new{ |hash, key| hash[key] = [] }
     end
@@ -150,7 +149,16 @@ module MuchRails::Action
       @much_rails_successful_action
     end
 
+    def controller_session=(value)
+      @controller_session = value
+    end
+
     private
+
+    def controller_session
+      @controller_session ||=
+        request&.env&.[]("action_controller.instance")&.session
+    end
 
     def default_action_success_result
       MuchRails::Action::HeadResult.new(:ok)

--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -18,7 +18,7 @@ module MuchRails::Action::Controller
   mixin_included do
     attr_reader :much_rails_action_class
 
-    before_action(
+    prepend_before_action(
       :require_much_rails_action_class,
       only: MuchRails::Action::Router.CONTROLLER_CALL_ACTION_METHOD_NAME,
     )

--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -9,23 +9,25 @@ module MuchRails::Action; end
 # MuchRails::Action::Controller defines the behaviors for controllers processing
 # MuchRails::Actions.
 module MuchRails::Action::Controller
-  DEFAULT_ACTION_CLASS_FORMAT = :any
-
   include MuchRails::Mixin
+
+  def self.DEFAULT_ACTION_CLASS_FORMAT
+    :any
+  end
 
   mixin_included do
     attr_reader :much_rails_action_class
 
     before_action(
       :require_much_rails_action_class,
-      only: MuchRails::Action::Router::CONTROLLER_CALL_ACTION_METHOD_NAME,
+      only: MuchRails::Action::Router.CONTROLLER_CALL_ACTION_METHOD_NAME,
     )
     before_action :permit_all_much_rails_action_params
   end
 
   mixin_instance_methods do
     define_method(
-      MuchRails::Action::Router::CONTROLLER_CALL_ACTION_METHOD_NAME,
+      MuchRails::Action::Router.CONTROLLER_CALL_ACTION_METHOD_NAME,
     ) do
       respond_to do |format|
         format.public_send(much_rails_action_class_format) do
@@ -41,7 +43,7 @@ module MuchRails::Action::Controller
     end
 
     define_method(
-      MuchRails::Action::Router::CONTROLLER_NOT_FOUND_METHOD_NAME,
+      MuchRails::Action::Router.CONTROLLER_NOT_FOUND_METHOD_NAME,
     ) do
       respond_to do |format|
         format.html do
@@ -51,11 +53,12 @@ module MuchRails::Action::Controller
     end
 
     def much_rails_action_class_name
-      "::#{params[MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME]}"
+      "::#{params[MuchRails::Action::Router.ACTION_CLASS_PARAM_NAME]}"
     end
 
     def much_rails_action_class_format
-      much_rails_action_class.format || DEFAULT_ACTION_CLASS_FORMAT
+      much_rails_action_class.format ||
+      MuchRails::Action::Controller.DEFAULT_ACTION_CLASS_FORMAT
     end
 
     def much_rails_action_params
@@ -67,7 +70,7 @@ module MuchRails::Action::Controller
           params
             .to_h
             .except(
-              MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME,
+              MuchRails::Action::Router.ACTION_CLASS_PARAM_NAME,
               :controller,
               :action,
             ),

--- a/lib/much-rails/action/controller.rb
+++ b/lib/much-rails/action/controller.rb
@@ -34,7 +34,6 @@ module MuchRails::Action::Controller
           result =
             much_rails_action_class.call(
               params: much_rails_action_params,
-              current_session: current_session,
               request: request,
             )
           instance_exec(result, &result.execute_block)

--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -6,10 +6,21 @@ module MuchRails; end
 module MuchRails::Action; end
 
 class MuchRails::Action::Router < MuchRails::Action::BaseRouter
-  DEFAULT_CONTROLLER_NAME = "application"
-  CONTROLLER_CALL_ACTION_METHOD_NAME = :much_rails_call_action
-  CONTROLLER_NOT_FOUND_METHOD_NAME = :much_rails_not_found
-  ACTION_CLASS_PARAM_NAME = :much_rails_action_class_name
+  def self.DEFAULT_CONTROLLER_NAME
+    "application"
+  end
+
+  def self.CONTROLLER_CALL_ACTION_METHOD_NAME
+    :much_rails_call_action
+  end
+
+  def self.CONTROLLER_NOT_FOUND_METHOD_NAME
+    :much_rails_not_found
+  end
+
+  def self.ACTION_CLASS_PARAM_NAME
+    :much_rails_action_class_name
+  end
 
   def self.url_class
     MuchRails::Action::Router::URL
@@ -38,7 +49,7 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
   def initialize(name = nil, controller_name: nil, &block)
     super(name, &block)
 
-    @controller_name = controller_name || DEFAULT_CONTROLLER_NAME
+    @controller_name = controller_name || self.class.DEFAULT_CONTROLLER_NAME
   end
 
   # Example:
@@ -49,8 +60,10 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
   #   end
   def apply_to(application_routes_draw_scope)
     validate!
-    draw_url_to   = "#{controller_name}##{CONTROLLER_NOT_FOUND_METHOD_NAME}"
-    draw_route_to = "#{controller_name}##{CONTROLLER_CALL_ACTION_METHOD_NAME}"
+    draw_url_to =
+      "#{controller_name}##{self.class.CONTROLLER_NOT_FOUND_METHOD_NAME}"
+    draw_route_to =
+      "#{controller_name}##{self.class.CONTROLLER_CALL_ACTION_METHOD_NAME}"
 
     definition_names = Set.new
 
@@ -63,7 +76,8 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
           as: (definition.name if definition_names.add?(definition.name)),
           defaults:
             definition.default_params.merge({
-              ACTION_CLASS_PARAM_NAME => request_type_action.class_name,
+              self.class.ACTION_CLASS_PARAM_NAME =>
+                request_type_action.class_name,
               "format" => request_type_action.format,
             }),
           constraints: request_type_action.constraints_lambda,
@@ -79,7 +93,8 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
         as: (definition.name if definition_names.add?(definition.name)),
         defaults:
           definition.default_params.merge({
-            ACTION_CLASS_PARAM_NAME => definition.default_action_class_name,
+            self.class.ACTION_CLASS_PARAM_NAME =>
+              definition.default_action_class_name,
             "format" => definition.default_action_format,
           }),
       )

--- a/test/support/fake_action_controller.rb
+++ b/test/support/fake_action_controller.rb
@@ -13,20 +13,31 @@ module FakeActionController
   end
 
   mixin_class_methods do
-    def before_action(method_name, **)
-      before_actions << method_name
+    def before_action(*args, &block)
+      before_action_calls << Assert::StubCall.new(*args, &block)
     end
 
-    def before_actions
-      @before_actions ||= []
+    def prepend_before_action(*args, &block)
+      prepend_before_action_calls << Assert::StubCall.new(*args, &block)
+    end
+
+    def before_action_calls
+      @before_action_calls ||= []
+    end
+
+    def prepend_before_action_calls
+      @prepend_before_action_calls ||= []
     end
   end
 
   mixin_instance_methods do
     def initialize(params)
       @params = FakeParams.new(params)
-      self.class.before_actions.each do |before_action|
-        public_send(before_action)
+      self.class.prepend_before_action_calls.each do |before_action_call|
+        public_send(before_action_call.args.first)
+      end
+      self.class.before_action_calls.each do |before_action_call|
+        public_send(before_action_call.args.first)
       end
     end
 

--- a/test/unit/action/controller_tests.rb
+++ b/test/unit/action/controller_tests.rb
@@ -29,6 +29,19 @@ module MuchRails::Action::Controller
     let(:receiver_class) do
       Class.new{ include FakeActionController }
     end
+
+    should "be configured as expected" do
+      assert_that(subject.prepend_before_action_calls.size).equals(1)
+      assert_that(subject.prepend_before_action_calls.last.args)
+        .equals([
+          :require_much_rails_action_class,
+          only: MuchRails::Action::Router.CONTROLLER_CALL_ACTION_METHOD_NAME,
+        ])
+
+      assert_that(subject.before_action_calls.size).equals(1)
+      assert_that(subject.before_action_calls.last.args)
+        .equals([:permit_all_much_rails_action_params])
+    end
   end
 
   class ReceiverInitTests < ReceiverTests

--- a/test/unit/action/controller_tests.rb
+++ b/test/unit/action/controller_tests.rb
@@ -17,8 +17,8 @@ module MuchRails::Action::Controller
       assert_that(subject).includes(MuchRails::Mixin)
     end
 
-    should "know its constants" do
-      assert_that(subject::DEFAULT_ACTION_CLASS_FORMAT).equals(:any)
+    should "know its attributes" do
+      assert_that(subject.DEFAULT_ACTION_CLASS_FORMAT).equals(:any)
     end
   end
 
@@ -41,7 +41,7 @@ module MuchRails::Action::Controller
 
     let(:params1) do
       {
-        MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME => "Actions::Show",
+        MuchRails::Action::Router.ACTION_CLASS_PARAM_NAME => "Actions::Show",
         controller: "actions",
         action: "show",
         nested: {
@@ -53,10 +53,10 @@ module MuchRails::Action::Controller
     should have_readers :much_rails_action_class
 
     should have_imeths(
-      MuchRails::Action::Router::CONTROLLER_CALL_ACTION_METHOD_NAME,
+      MuchRails::Action::Router.CONTROLLER_CALL_ACTION_METHOD_NAME,
     )
     should have_imeths(
-      MuchRails::Action::Router::CONTROLLER_NOT_FOUND_METHOD_NAME,
+      MuchRails::Action::Router.CONTROLLER_NOT_FOUND_METHOD_NAME,
     )
     should have_imeths :much_rails_action_class_name
     should have_imeths :much_rails_action_class_format
@@ -69,7 +69,7 @@ module MuchRails::Action::Controller
         .equals("::Actions::Show")
 
       assert_that(subject.much_rails_action_class_format)
-        .equals(unit_module::DEFAULT_ACTION_CLASS_FORMAT)
+        .equals(unit_module.DEFAULT_ACTION_CLASS_FORMAT)
 
       assert_that(subject.much_rails_action_params)
         .equals(
@@ -91,7 +91,7 @@ module MuchRails::Action::Controller
 
     let(:params1) do
       {
-        MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME =>
+        MuchRails::Action::Router.ACTION_CLASS_PARAM_NAME =>
           "Actions::Unknown",
       }
     end

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -16,17 +16,17 @@ class MuchRails::Action::Router
 
     should have_imeths :url_class
 
-    should "be a BaseRouter" do
+    should "be configured as expected" do
       assert_that(subject < MuchRails::Action::BaseRouter).is_true
     end
 
-    should "know its constants" do
-      assert_that(subject::DEFAULT_CONTROLLER_NAME).equals("application")
-      assert_that(subject::CONTROLLER_CALL_ACTION_METHOD_NAME)
+    should "know its attributes" do
+      assert_that(subject.DEFAULT_CONTROLLER_NAME).equals("application")
+      assert_that(subject.CONTROLLER_CALL_ACTION_METHOD_NAME)
         .equals(:much_rails_call_action)
-      assert_that(subject::CONTROLLER_NOT_FOUND_METHOD_NAME)
+      assert_that(subject.CONTROLLER_NOT_FOUND_METHOD_NAME)
         .equals(:much_rails_not_found)
-      assert_that(subject::ACTION_CLASS_PARAM_NAME)
+      assert_that(subject.ACTION_CLASS_PARAM_NAME)
         .equals(:much_rails_action_class_name)
       assert_that(subject.url_class).equals(unit_class::URL)
     end
@@ -64,7 +64,7 @@ class MuchRails::Action::Router
 
     should "know its attributes" do
       assert_that(subject.controller_name)
-        .equals(unit_class::DEFAULT_CONTROLLER_NAME)
+        .equals(unit_class.DEFAULT_CONTROLLER_NAME)
 
       router = unit_class.new(controller_name: controller_name1)
       assert_that(router.controller_name).equals(controller_name1)
@@ -99,13 +99,13 @@ class MuchRails::Action::Router
 
       expected_draw_url_to =
         "#{subject.controller_name}"\
-        "##{unit_class::CONTROLLER_NOT_FOUND_METHOD_NAME}"
+        "##{unit_class.CONTROLLER_NOT_FOUND_METHOD_NAME}"
       expected_draw_route_to =
         "#{subject.controller_name}"\
-        "##{unit_class::CONTROLLER_CALL_ACTION_METHOD_NAME}"
+        "##{unit_class.CONTROLLER_CALL_ACTION_METHOD_NAME}"
       expected_default_defaults =
         {
-          unit_class::ACTION_CLASS_PARAM_NAME => default_class_name,
+          unit_class.ACTION_CLASS_PARAM_NAME => default_class_name,
           "format" => :html,
         }
 
@@ -117,7 +117,7 @@ class MuchRails::Action::Router
           as: url_name,
           defaults:
             {
-              unit_class::ACTION_CLASS_PARAM_NAME => request_type_class_name,
+              unit_class.ACTION_CLASS_PARAM_NAME => request_type_class_name,
               "format" => :html,
             },
           constraints: request_type_proc,

--- a/test/unit/action/unprocessable_entity_result_tests.rb
+++ b/test/unit/action/unprocessable_entity_result_tests.rb
@@ -20,7 +20,7 @@ class MuchRails::Action::UnprocessableEntityResult
     let(:controller1){ FakeController.new(params1) }
     let(:params1) do
       {
-        MuchRails::Action::Router::ACTION_CLASS_PARAM_NAME => "Actions::Show",
+        MuchRails::Action::Router.ACTION_CLASS_PARAM_NAME => "Actions::Show",
       }
     end
     let(:errors1) do

--- a/test/unit/change_action_tests.rb
+++ b/test/unit/change_action_tests.rb
@@ -57,14 +57,7 @@ module MuchRails::ChangeAction
 
   class InitTests < ReceiverTests
     desc "when init"
-    subject{ receiver_class.new(params: {}) }
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     setup do
       Assert.stub(subject, :any_unextracted_change_result_validation_errors?) do
@@ -84,13 +77,7 @@ module MuchRails::ChangeAction
 
   class RecordErrorsWithResultExceptionTests < InitTests
     desc "with record errors and a result exception"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     setup do
       Assert.stub(subject, :any_unextracted_change_result_validation_errors?) do
@@ -118,13 +105,7 @@ module MuchRails::ChangeAction
 
   class RecordErrorsWithNoResultExceptionTests < InitTests
     desc "with record errors and no result exception"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     setup do
       Assert.stub(subject, :any_unextracted_change_result_validation_errors?) do
@@ -149,13 +130,7 @@ module MuchRails::ChangeAction
 
   class ChangeResultMethodTests < InitTests
     desc "#change_result method"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     should "memoize and return the expected Result" do
       result = subject.change_result
@@ -178,13 +153,7 @@ module MuchRails::ChangeAction
 
   class AnyUnextractedChangeResultValidationErrorsMethodTests < ReceiverTests
     desc "#any_unextracted_change_result_validation_errors? method"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     let(:receiver_class) do
       Class.new do
@@ -205,13 +174,7 @@ module MuchRails::ChangeAction
   class NoValidationErrorsTests <
           AnyUnextractedChangeResultValidationErrorsMethodTests
     desc "with no validation errors"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     let(:receiver_class) do
       Class.new do
@@ -232,13 +195,7 @@ module MuchRails::ChangeAction
   class ValidationErrorsTests <
           AnyUnextractedChangeResultValidationErrorsMethodTests
     desc "with validation errors"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     let(:receiver_class) do
       Class.new do

--- a/test/unit/destroy_action_tests.rb
+++ b/test/unit/destroy_action_tests.rb
@@ -50,13 +50,7 @@ module MuchRails::DestroyAction
 
   class InitTests < ReceiverTests
     desc "when init"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     should have_imeths :destroy_result
 

--- a/test/unit/save_action_tests.rb
+++ b/test/unit/save_action_tests.rb
@@ -50,13 +50,7 @@ module MuchRails::SaveAction
 
   class InitTests < ReceiverTests
     desc "when init"
-    subject do
-      receiver_class.new(
-        params: {},
-        current_session: nil,
-        request: nil,
-      )
-    end
+    subject{ receiver_class.new(params: {}, request: nil) }
 
     should have_imeths :save_result
 


### PR DESCRIPTION
This removes the previous `current_session` keyword argument that
was intended to allow injecting user session objects. It is
replaces with a private `controller_session` method that is the
Rails controller instance's session. This allows for an easier
and more extendable API for interacting with session data.

This also adds a public `controller_session=` writer to ease
injecting fake session objects when unit testing actions.

# Other Changes

### switch to requiring the much rails action class in a prepended controller before_action callback

This ensures the much rails action class is available for any
subsequent controller action callbacks. This is helpful if you
e.g. want to use singleton DSL methods on Action classes to change
behavior in Rails controller callbacks.

### switch to late-bound constants-via-singleton-methods

This is the preferred way to define constant values as they
achieve the same effect as traditional constants but do so in
a late-bound fashion.

I noticed this cleanup while planning for the adding a controller
session API to Actions.