### PR TITLE
update MuchRails::ChangeActionResult to always return Arrays when extracting validation errors

### DIFF
--- a/lib/much-rails/change_action_result.rb
+++ b/lib/much-rails/change_action_result.rb
@@ -40,7 +40,7 @@ class MuchRails::ChangeActionResult
   end
 
   def extract_validation_error(field_name)
-    validation_errors.delete(field_name)
+    Array.wrap(validation_errors.delete(field_name)).compact
   end
 
   def any_unextracted_validation_errors?

--- a/test/unit/change_action_result_tests.rb
+++ b/test/unit/change_action_result_tests.rb
@@ -64,10 +64,14 @@ class MuchRails::ChangeActionResult
   class ValidationMethodsTests < UnitTests
     desc "validation methods"
     subject do
-      unit_class.failure(validation_errors: {
-        name: ["NAME ERROR"],
-        other: ["OTHER ERROR"],
-      })
+      unit_class.failure(
+        validation_errors: {
+          name: ["NAME ERROR"],
+          other: ["OTHER ERROR"],
+          empty: [],
+          none: nil,
+        },
+      )
     end
 
     should "know its attributes" do
@@ -76,6 +80,8 @@ class MuchRails::ChangeActionResult
         .equals({
           name: ["NAME ERROR"],
           other: ["OTHER ERROR"],
+          empty: [],
+          none: [nil],
         })
 
       # validation_error_messages
@@ -90,6 +96,12 @@ class MuchRails::ChangeActionResult
         .equals(["NAME ERROR"])
       assert_that(subject.extract_validation_error(:other))
         .equals(["OTHER ERROR"])
+      assert_that(subject.extract_validation_error(:empty))
+        .equals([])
+      assert_that(subject.extract_validation_error(:none))
+        .equals([])
+      assert_that(subject.extract_validation_error(:unknown))
+        .equals([])
       assert_that(subject.validation_errors).is_empty
 
       # any_unextracted_validation_errors?


### PR DESCRIPTION
This means the consumers of this API can make an assumption that
they will always get an Array back. If there are no errors for
the given field name, then they get an empty array back.
