### PR TITLE
switch to using indifferent hash access on ChangeActionResult validation errors

### DIFF
--- a/lib/much-rails/change_action_result.rb
+++ b/lib/much-rails/change_action_result.rb
@@ -27,12 +27,15 @@ class MuchRails::ChangeActionResult
 
     @service_result = save_service_result
 
-    @service_result.validation_errors ||= {}
+    @service_result.validation_errors ||= HashWithIndifferentAccess.new
   end
 
   def validation_errors
     @validation_errors ||=
-      service_result.get_for_all_results(:validation_errors).to_h
+      service_result
+        .get_for_all_results(:validation_errors)
+        .to_h
+        .with_indifferent_access
   end
 
   def validation_error_messages

--- a/test/unit/change_action_result_tests.rb
+++ b/test/unit/change_action_result_tests.rb
@@ -78,11 +78,13 @@ class MuchRails::ChangeActionResult
       # validation_errors
       assert_that(subject.validation_errors)
         .equals({
-          name: ["NAME ERROR"],
-          other: ["OTHER ERROR"],
-          empty: [],
-          none: [nil],
+          "name" => ["NAME ERROR"],
+          "other" => ["OTHER ERROR"],
+          "empty" => [],
+          "none" => [nil],
         })
+      assert_that(subject.validation_errors[:name]).equals(["NAME ERROR"])
+      assert_that(subject.validation_errors["name"]).equals(["NAME ERROR"])
 
       # validation_error_messages
       assert_that(subject.validation_error_messages)
@@ -94,11 +96,11 @@ class MuchRails::ChangeActionResult
       # extract_validation_error
       assert_that(subject.extract_validation_error(:name))
         .equals(["NAME ERROR"])
-      assert_that(subject.extract_validation_error(:other))
+      assert_that(subject.extract_validation_error("other"))
         .equals(["OTHER ERROR"])
       assert_that(subject.extract_validation_error(:empty))
         .equals([])
-      assert_that(subject.extract_validation_error(:none))
+      assert_that(subject.extract_validation_error("none"))
         .equals([])
       assert_that(subject.extract_validation_error(:unknown))
         .equals([])


### PR DESCRIPTION
This ensures the access method doesn't cause validation errors to
slip through the cracks and plays better with other Rails APIs
that expect indifferent access hashes.
