### PR TITLE
load nested named routes files

### DIFF
--- a/lib/much-rails/action/router.rb
+++ b/lib/much-rails/action/router.rb
@@ -39,7 +39,10 @@ class MuchRails::Action::Router < MuchRails::Action::BaseRouter
       raise ArgumentError, "routes file `#{file_path.inspect}` does not exist."
     end
 
-    new(routes_file_name, controller_name: controller_name) do
+    new(
+      routes_file_name.to_s.split(File::SEPARATOR).join("_"),
+      controller_name: controller_name,
+    ) do
       instance_eval(File.read(file_path), file_path.to_s, 1)
     end
   end

--- a/test/support/config/routes/test/subrouter.rb
+++ b/test/support/config/routes/test/subrouter.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+url :root, "/subrouter"

--- a/test/unit/action/router_tests.rb
+++ b/test/unit/action/router_tests.rb
@@ -45,6 +45,12 @@ class MuchRails::Action::Router
       assert_that(router.url_set.fetch(:root).path).equals("/")
     end
 
+    should "eval the nested named routes file" do
+      router = unit_class.load("test/subrouter")
+      assert_that(router.url_set).is_not_empty
+      assert_that(router.url_set.fetch(:root).path).equals("/subrouter")
+    end
+
     should "complain if no file name given" do
       assert_that{ unit_class.load([nil, "", "  "]) }.raises(ArgumentError)
     end


### PR DESCRIPTION
This allows you to nest route files in a folder and have the named
routes be namespaced appropriately. This allows you to further
break down large sections of routes into named sub-routers if
desired.
