### PR TITLE
add MuchRails::Layout.external_javascript handling

### DIFF
--- a/lib/much-rails/layout.rb
+++ b/lib/much-rails/layout.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "much-rails"
 require "much-rails/layout/helper"
 require "much-rails/mixin"
 require "much-rails/view_models/breadcrumb"
@@ -48,6 +49,14 @@ module MuchRails::Layout
 
     def javascripts
       @javascripts ||= []
+    end
+
+    def external_javascript(value = nil, &block)
+      external_javascripts << (block || ->{ value })
+    end
+
+    def external_javascripts
+      @external_javascripts ||= []
     end
 
     def head_link(url, **attributes)
@@ -110,6 +119,10 @@ module MuchRails::Layout
 
     def javascripts
       @javascripts ||= self.class.javascripts.map(&:call)
+    end
+
+    def external_javascripts
+      @external_javascripts ||= self.class.external_javascripts.map(&:call)
     end
 
     def head_links

--- a/test/unit/layout_tests.rb
+++ b/test/unit/layout_tests.rb
@@ -32,6 +32,7 @@ module MuchRails::Layout
     should have_imeths :page_title, :page_titles, :application_page_title
     should have_imeths :breadcrumb, :breadcrumbs
     should have_imeths :stylesheet, :stylesheets, :javascript, :javascripts
+    should have_imeths :external_javascript, :external_javascripts
     should have_imeths :head_link, :head_links, :layout, :layouts
   end
 
@@ -133,6 +134,24 @@ module MuchRails::Layout
           "some/other/javascript/pack.js",
           "https://some/javascript/file.js",
           "https://some/other/javascript/file.js",
+        ])
+    end
+
+    should "know its external_javascripts" do
+      receiver = receiver_class.new
+      assert_that(receiver.external_javascripts).is_empty
+
+      receiver_class.external_javascript("some/ext_js/pack.js")
+      receiver_class.external_javascript{ "some/other/ext_js/pack.js" }
+      receiver_class.external_javascript("https://some/ext_js/file.js")
+      receiver_class.external_javascript{ "https://some/other/ext_js/file.js" }
+
+      assert_that(subject.external_javascripts)
+        .equals([
+          "some/ext_js/pack.js",
+          "some/other/ext_js/pack.js",
+          "https://some/ext_js/file.js",
+          "https://some/other/ext_js/file.js",
         ])
     end
 


### PR DESCRIPTION
This matches the `.javascript` handling but creates a separate
(but optional) "bucket" for defining javascripts that aren't
internal to the application and don't need MuchRails::Assets
handling in their script tag markup.

E.g. you could use this by adding something like this to the
`application.html.erb` layout template:

```html
...
  <head>
    ...

    <% @view.external_javascripts.each do |external_javascript| %>
      <script src="<%= external_javascript %>"></script>
    <% end %>
    <% @view.javascripts.each do |javascript| %>
      <script src="<%= MuchRails::Assets[javascript].url %>" type="module"></script>
    <% end %>

    ...
  </head>
...
```

This is all optional and isn't required to use MuchRails. But this
adds the API and makes it available as needed.
