### PR TITLE
host CSS/JS assets out of the app/views folder

### DIFF
--- a/lib/much-rails/assets.rb
+++ b/lib/much-rails/assets.rb
@@ -63,7 +63,28 @@ module MuchRails::Assets
       config.source rails.root.join("app", "assets", "vendor") do |s|
         s.base_path "vendor"
       end
+
+      # Look for CSS/JS files in the app/views folder. Support ERB
+      # on all .scss/.js files. Support compilation of .scss files.
+      config.source rails.root.join("app", "views") do |s|
+        # Reject SCSS partials
+        # Only include SCSS, CSS, and JS files
+        # (e.g. don't host resource.js.erb rails templates)
+        s.filter do |paths|
+          paths
+            .reject{ |p| File.basename(p) =~ /^_.*\.scss$/ }
+            .select{ |p| File.basename(p) =~ /\.scss|css|js$/ }
+        end
+
+        s.engine "scss", MuchRails::Assets::Erubi::Engine
+        s.engine "scss", MuchRails::Assets::Sass::Engine, {
+          syntax: "scss",
+          output_style: "compressed",
+        }
+        s.engine "js", MuchRails::Assets::Erubi::Engine
+      end
     end
+
     MuchRails::Assets.init
   end
 end

--- a/test/unit/assets_tests.rb
+++ b/test/unit/assets_tests.rb
@@ -96,6 +96,25 @@ module MuchRails::Assets
       assert_that(source.engines.empty?).is_true
     end
 
+    should "configure the app's app/views folder as a source" do
+      source =
+        subject.config.sources.find do |source|
+          source.path == FakeRails.root.join("app", "views").to_s
+        end
+
+      assert_that(source).is_not_nil
+
+      assert_that(source.engines["scss"].size).equals(2)
+      assert_that(source.engines["scss"].first)
+        .is_instance_of(subject::Erubi::Engine)
+      assert_that(source.engines["scss"].last)
+        .is_instance_of(subject::Sass::Engine)
+
+      assert_that(source.engines["js"].size).equals(1)
+      assert_that(source.engines["js"].first)
+        .is_instance_of(subject::Erubi::Engine)
+    end
+
     should "initialize itself" do
       assert_that(@init_call).is_not_nil
     end


### PR DESCRIPTION
This allows you to store CSS/JS that supports your view templates
right alongside the templates themselves (not in a completely
separate folder). This not only juxtaposes the logic, but ensures
the assets are hosted in a logic path that matches the resources
they support.

Note: I added restrictive filtering to only support CSS/JS for now.
My thinking is that only CSS/JS needs to directly map and be
juxtaposed to templates. Images and "app" CSS/JS are global to the
entire app and can be hosted out of the `app/assets` folder as
before. This restrictive filtering also ensures MuchRails::Assets
won't unintentionally host e.g. `resource/show.js.erb` Rails
templates.

# Demo

Here is an example using this in a Rails app:
![imageo34c1](https://user-images.githubusercontent.com/82110/126038887-b21c30cf-dc00-4222-b3f7-adc536b33018.jpg)

